### PR TITLE
ci: add ruff lint+format workflow (Task A.1 from #158)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [develop, main]
+
+# Cancel in-progress runs on the same branch when a new push lands,
+# except on the protected branches where every commit should produce a record.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/main' }}
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: ruff
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          # New uv.lock invalidates the cache automatically.
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install ruff
+        # Lint needs only ruff, not the app runtime. --locked still checks
+        # uv.lock against pyproject.toml.
+        run: uv sync --locked --only-group dev --no-install-project
+
+      - name: Ruff lint
+        run: uv run --no-sync ruff check .
+
+      - name: Ruff format check
+        run: uv run --no-sync ruff format --check .

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,56 @@
+# Ruff configuration
+
+target-version = "py311"
+line-length = 100
+src = ["aTrain"]
+extend-exclude = [
+  ".venv",
+  "build",
+  "dist",
+  "aTrain.egg-info",
+  "aTrain/required_models",
+]
+
+[lint]
+select = [
+  "E", "F", "W",  # pycodestyle / pyflakes
+  "I",            # isort
+  "B",            # bugbear
+  "UP",           # pyupgrade
+  "SIM",          # simplify
+  "RUF",          # ruff-specific
+  "S",            # bandit-style security checks
+  "RET",          # return-statement quality
+  "C4",           # comprehensions
+  "A",            # builtin shadowing
+  "N",            # naming
+]
+ignore = [
+  "E501",   # line length is the formatter's job, not the linter's
+  "S603",   # subprocess: aTrain calls xdg-open with a static argv, not a shell
+  "RET504", # named intermediate variables serve as in-line documentation
+  "SIM105", # try/except <exc>: pass is idiomatic, contextlib.suppress is a style preference (not a safety win)
+]
+
+[lint.per-file-ignores]
+"aTrain/__init__.py"        = ["N999"]   # project name aTrain intentionally capitalised
+"aTrain/__main__.py"        = ["N999"]   # project name aTrain intentionally capitalised
+"aTrain/pages/**/*.py"      = ["SIM117"] # NiceGUI: nested `with` reflects the UI tree
+"aTrain/components/**/*.py" = ["SIM117"] # NiceGUI: nested `with` reflects the UI tree
+
+# --- Grandfathered findings that need a manual (non-auto-fixable) code
+# change. Deferred to small, focused follow-up PRs so the behaviour change
+# is reviewable alongside test coverage (per review on #160). Each entry
+# is removed in the PR that applies the corresponding fix.
+"aTrain/components/settings/advanced.py"          = ["A002"]   # `open` param shadows builtin
+"aTrain/components/settings/model.py"             = ["A001"]   # `input` var shadows builtin
+"aTrain/components/settings/speaker_count.py"     = ["A001"]   # `input` var shadows builtin
+"aTrain/components/settings/speaker_detection.py" = ["A001"]   # `input` var shadows builtin
+"aTrain/components/settings/language.py"          = ["RUF015"] # list(d.keys())[0] -> next(iter(d))
+"aTrain/components/splash_screen.py"              = ["SIM118"] # `in d.keys()` -> `in d`
+"aTrain/utils/models.py"                          = ["B904", "SIM118"]  # raise ... from; in d.keys()
+"aTrain/utils/archive.py"                         = ["S607"]   # partial exe path for xdg-open
+
+[format]
+quote-style = "double"
+indent-style = "space"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,22 @@ uv run aTrain start     # run the app
 If you do not have uv installed yet, see the
 [uv installation guide](https://docs.astral.sh/uv/#installation).
 
+## Running the CI checks locally
+
+The CI workflow runs `ruff` for linting and format checking. To
+reproduce the same checks locally before pushing:
+
+```bash
+uv sync --group dev             # install dev tools (ruff)
+uv run ruff check .             # lint
+uv run ruff format --check .    # format check (no rewrites)
+uv run ruff format .            # apply formatter
+```
+
+`uv sync --locked --group dev` is also used by CI to validate that
+`uv.lock` is in sync with `pyproject.toml`. Running `uv lock` locally
+after any dependency change keeps the lockfile current.
+
 # Branching
 
 As the project grows and community contributions become more frequent (thanks all!) we opted to adopt a branching model with the intention to make it easier and clearer for contributors to make pull requests.

--- a/aTrain/app.py
+++ b/aTrain/app.py
@@ -1,19 +1,16 @@
 import os
 from importlib.resources import files
 from pathlib import Path
-from typing import cast
+from typing import Annotated, cast
 from unittest.mock import patch
 
 from aTrain_core.globals import ATRAIN_DIR, FLATPAK, REQUIRED_MODELS
 from aTrain_core.load_resources import get_model
 from platformdirs import user_config_path
 from typer import Option, Typer
-from typing_extensions import Annotated
 from wakepy import keep
 
-NICEGUI_STORAGE_PATH = (
-    user_config_path() / "aTrain" if FLATPAK else (ATRAIN_DIR / "settings")
-)
+NICEGUI_STORAGE_PATH = user_config_path() / "aTrain" if FLATPAK else (ATRAIN_DIR / "settings")
 
 with patch.dict(os.environ, NICEGUI_STORAGE_PATH=str(NICEGUI_STORAGE_PATH)):
     from nicegui import ui

--- a/aTrain/components/dialogs/delete.py
+++ b/aTrain/components/dialogs/delete.py
@@ -1,6 +1,5 @@
-from nicegui import ui
-
 from aTrain.utils.archive import delete_transcription as delete
+from nicegui import ui
 
 
 def dialog_delete():

--- a/aTrain/components/dialogs/download.py
+++ b/aTrain/components/dialogs/download.py
@@ -4,10 +4,9 @@ from multiprocessing.managers import DictProxy
 from pathlib import Path
 from typing import cast
 
+from aTrain.components.dialogs.process import update_time
 from nicegui import ElementFilter, app, ui
 from nicegui.run import tear_down as stop_download
-
-from aTrain.components.dialogs.process import update_time
 
 GIF_DOWNLOAD = cast(Path, files("aTrain") / "static" / "images" / "download.gif")
 

--- a/aTrain/components/dialogs/finished.py
+++ b/aTrain/components/dialogs/finished.py
@@ -2,9 +2,8 @@ from importlib.resources import files
 from pathlib import Path
 from typing import cast
 
-from nicegui import app, ui
-
 from aTrain.utils.archive import open_file_directory
+from nicegui import app, ui
 
 GIF_FINISHED = cast(Path, files("aTrain") / "static" / "images" / "success.gif")
 
@@ -19,9 +18,7 @@ def dialog_finished(file_id: str):
         ui.image(GIF_FINISHED).classes("w-1/2 h-1/2 mx-auto")
         ui.separator()
         with ui.row().classes("justify-between w-full items-center"):
-            ui.label("").bind_text_from(
-                state, "time", lambda x: f"We transcribed your file in {x}"
-            )
+            ui.label("").bind_text_from(state, "time", lambda x: f"We transcribed your file in {x}")
             with ui.row():
                 btn_open = ui.button("Open", color="gray-200")
                 btn_open.props("unelevated no-caps text-color=dark")

--- a/aTrain/components/layout/footer.py
+++ b/aTrain/components/layout/footer.py
@@ -6,7 +6,9 @@ from nicegui import ui
 
 BANDAS_LOGO = cast(Path, files("aTrain") / "static" / "images" / "Bandas_Logo.svg")
 PAPER_TEXT = "Using aTrain for research? Please cite our paper:"
-PAPER_TITLE = "Take the aTrain. Introducing an interface for the Accessible Transcription of Interviews"
+PAPER_TITLE = (
+    "Take the aTrain. Introducing an interface for the Accessible Transcription of Interviews"
+)
 PAPER_LINK = "https://doi.org/10.1016/j.jbef.2024.100891"
 
 

--- a/aTrain/components/layout/header.py
+++ b/aTrain/components/layout/header.py
@@ -2,9 +2,8 @@ from importlib.resources import files
 from pathlib import Path
 from typing import cast
 
-from nicegui import ui
-
 from aTrain.version import __version__
+from nicegui import ui
 
 ATRAIN_LOGO = cast(Path, files("aTrain") / "static" / "images" / "logo.svg")
 GITHUB_LOGO = cast(Path, files("aTrain") / "static" / "images" / "github.svg")

--- a/aTrain/components/settings/advanced.py
+++ b/aTrain/components/settings/advanced.py
@@ -83,18 +83,12 @@ def input_temperature():
         ui.separator()
 
         with ui.row().classes("w-full gap-2 items-center"):
-            number = ui.number(
-                min=0.0, max=1.0, step=0.1, precision=1, placeholder="auto"
-            )
+            number = ui.number(min=0.0, max=1.0, step=0.1, precision=1, placeholder="auto")
             number.props("filled bg-color=gray-100 color=dark").classes("flex-grow")
-            number.bind_value(
-                app.storage.general, "temperature_override"
-            )  # <- New state name
+            number.bind_value(app.storage.general, "temperature_override")  # <- New state name
 
             reset_btn = ui.button(icon="refresh", color="gray-300")
-            reset_btn.props("flat dense round size=sm").tooltip(
-                "Reset to default (auto)"
-            )
+            reset_btn.props("flat dense round size=sm").tooltip("Reset to default (auto)")
             reset_btn.on_click(lambda: number.set_value(None))
 
     # Fix wrong default setting from version 1.4.0, TODO: Revert state name to "temperature" in upcoming releases

--- a/aTrain/components/settings/file.py
+++ b/aTrain/components/settings/file.py
@@ -1,5 +1,4 @@
 import os
-from typing import Optional
 
 from aTrain_core.globals import FLATPAK
 from aTrain_core.settings import load_formats
@@ -56,7 +55,7 @@ def input_file() -> CustomUpload:
     uploader.selected_path = None
     select_button.text = "Select File"
 
-    def pick_file_native() -> Optional[str]:
+    def pick_file_native() -> str | None:
         try:
             import gi  # type: ignore
 
@@ -101,7 +100,7 @@ def input_file() -> CustomUpload:
                 None,
             )
 
-            filename: Optional[str] = None
+            filename: str | None = None
             loop = GLib.MainLoop()
 
             def on_response(_proxy, _sender, _signal, params):

--- a/aTrain/components/settings/language.py
+++ b/aTrain/components/settings/language.py
@@ -1,6 +1,5 @@
-from nicegui import ElementFilter, app, ui
-
 from aTrain.utils.models import model_languages
+from nicegui import ElementFilter, app, ui
 
 
 def input_language():

--- a/aTrain/components/settings/model.py
+++ b/aTrain/components/settings/model.py
@@ -1,8 +1,7 @@
-from aTrain_core.globals import REQUIRED_MODELS
-from nicegui import app, ui
-
 from aTrain.components.settings.language import update_language_options
 from aTrain.utils.models import read_transcription_models
+from aTrain_core.globals import REQUIRED_MODELS
+from nicegui import app, ui
 
 
 def input_model():

--- a/aTrain/components/settings/speaker_count.py
+++ b/aTrain/components/settings/speaker_count.py
@@ -12,9 +12,7 @@ def input_speaker_count():
             input.bind_value(app.storage.general, "speaker_count")
 
             reset_btn = ui.button(icon="refresh", color="gray-300")
-            reset_btn.props("flat dense round size=sm").tooltip(
-                "Reset to default (auto-detect)"
-            )
+            reset_btn.props("flat dense round size=sm").tooltip("Reset to default (auto-detect)")
             reset_btn.on_click(lambda: input.set_value(None))
 
     column.bind_visibility(app.storage.general, "speaker_detection")

--- a/aTrain/components/settings/speaker_detection.py
+++ b/aTrain/components/settings/speaker_detection.py
@@ -1,4 +1,4 @@
-from nicegui import ui, app
+from nicegui import app, ui
 
 
 def input_speaker_detection():

--- a/aTrain/layouts/base.py
+++ b/aTrain/layouts/base.py
@@ -1,8 +1,9 @@
 from contextlib import contextmanager
-from nicegui import ui
-from aTrain.components.layout.header import header
+
 from aTrain.components.layout.footer import footer
+from aTrain.components.layout.header import header
 from aTrain.components.layout.sidebar import sidebar
+from nicegui import ui
 
 
 @contextmanager

--- a/aTrain/pages/about.py
+++ b/aTrain/pages/about.py
@@ -1,6 +1,5 @@
-from nicegui import ui
-
 from aTrain.layouts.base import base_layout
+from nicegui import ui
 
 AUTHORS = ["Armin Haberl", "Jürgen Fleiß", "Dominik Kowald", "Stefan Thalmann"]
 DEVELOPERS = ["Armin Haberl", "Jürgen Fleiß", "Andrea Forster (former)"]

--- a/aTrain/pages/archive.py
+++ b/aTrain/pages/archive.py
@@ -1,10 +1,9 @@
-from nicegui import ui
-
 from aTrain.components.dialogs.delete import dialog_delete
 from aTrain.layouts.base import base_layout
 from aTrain.utils.archive import delete_transcription as delete
 from aTrain.utils.archive import open_file_directory as show
 from aTrain.utils.archive import read_archive
+from nicegui import ui
 
 
 @ui.page("/archive")

--- a/aTrain/pages/faq.py
+++ b/aTrain/pages/faq.py
@@ -1,7 +1,6 @@
-from nicegui import ui
-
 from aTrain.layouts.base import base_layout
 from aTrain.utils.archive import load_faqs
+from nicegui import ui
 
 
 @ui.page("/faq")

--- a/aTrain/pages/models.py
+++ b/aTrain/pages/models.py
@@ -1,8 +1,7 @@
-from aTrain_core.globals import REQUIRED_MODELS
-from nicegui import ui
-
 from aTrain.layouts.base import base_layout
 from aTrain.utils.models import download_model, read_model_metadata, remove_model
+from aTrain_core.globals import REQUIRED_MODELS
+from nicegui import ui
 
 
 @ui.page("/models")
@@ -39,6 +38,4 @@ def page():
                             else:
                                 btn_download = ui.button("Download", color="dark")
                                 btn_download.props("no-caps size=0.7rem unelevated")
-                                btn_download.on_click(
-                                    lambda m=model: download_model(m["model"])
-                                )
+                                btn_download.on_click(lambda m=model: download_model(m["model"]))

--- a/aTrain/pages/transcribe.py
+++ b/aTrain/pages/transcribe.py
@@ -1,9 +1,6 @@
 from pathlib import Path
 from types import SimpleNamespace
 
-from aTrain_core.globals import FLATPAK
-from nicegui import Client, ui
-
 from aTrain.components.settings.advanced import advanced_settings
 from aTrain.components.settings.file import input_file
 from aTrain.components.settings.language import input_language
@@ -13,6 +10,8 @@ from aTrain.components.settings.speaker_detection import input_speaker_detection
 from aTrain.components.splash_screen import splash_screen
 from aTrain.layouts.base import base_layout
 from aTrain.utils.transcription import start_transcription
+from aTrain_core.globals import FLATPAK
+from nicegui import Client, ui
 
 
 @ui.page("/")
@@ -44,9 +43,7 @@ async def page(client: Client):
                     )
                     await start_transcription(payload)
 
-                start_btn = ui.button(
-                    "Start", on_click=start_from_selected, color="dark"
-                )
+                start_btn = ui.button("Start", on_click=start_from_selected, color="dark")
             else:
                 start_btn = ui.button("Start", on_click=file.upload, color="dark")
             start_btn.props("no-caps unelevated")

--- a/aTrain/utils/archive.py
+++ b/aTrain/utils/archive.py
@@ -19,9 +19,7 @@ def read_archive() -> list:
 def read_directories() -> list:
     """A function that returns a list of all directories in the archive folder"""
     os.makedirs(TRANSCRIPT_DIR, exist_ok=True)
-    directories = [
-        directory.name for directory in os.scandir(TRANSCRIPT_DIR) if directory.is_dir()
-    ]
+    directories = [directory.name for directory in os.scandir(TRANSCRIPT_DIR) if directory.is_dir()]
     directories.sort(reverse=True)
     return directories
 
@@ -41,7 +39,7 @@ def read_all_metadata(all_directories) -> list:
 
 def read_metadata_file(metadata_file_path, directory) -> dict:
     """A function that reads the content of a metadata file for a given transcription."""
-    with open(metadata_file_path, "r", encoding="utf-8") as metadata_file:
+    with open(metadata_file_path, encoding="utf-8") as metadata_file:
         metadata: dict = yaml.safe_load(metadata_file)
         metadata["file_id"] = directory
     return metadata
@@ -81,7 +79,7 @@ def open_file_directory(file_id) -> None:
 def load_faqs() -> dict:
     """A function that reads the content of the faq file."""
     faq_path = str(files("aTrain.static").joinpath("faq.yaml"))
-    with open(faq_path, "r", encoding="utf-8") as faq_file:
+    with open(faq_path, encoding="utf-8") as faq_file:
         faqs: dict = yaml.safe_load(faq_file)
     return faqs
 
@@ -92,9 +90,8 @@ def check_access(path: str) -> bool:
         # Check if the directory exists and is readable
         if os.path.isdir(path):
             return len(os.listdir(path)) >= 0
-        else:
-            with open(path, "r") as f:
-                f.read()
+        with open(path) as f:
+            f.read()
         return True
     except PermissionError:
         return False

--- a/aTrain/utils/models.py
+++ b/aTrain/utils/models.py
@@ -5,15 +5,14 @@ import urllib.request
 from concurrent.futures.process import BrokenProcessPool
 from multiprocessing import Manager
 
-from aTrain_core.settings import load_languages
+from aTrain.components.dialogs.download import close_dialog_download, dialog_download
+from aTrain.components.dialogs.error import dialog_error
 from aTrain_core.globals import MODELS_DIR, REQUIRED_MODELS_DIR
 from aTrain_core.load_resources import get_model, load_model_config_file, remove_model
+from aTrain_core.settings import load_languages
 from nicegui import run, ui
 from nicegui.run import SubprocessException
 from nicegui.run import setup as setup_process_pool
-
-from aTrain.components.dialogs.download import close_dialog_download, dialog_download
-from aTrain.components.dialogs.error import dialog_error
 
 
 def read_downloaded_models() -> list:
@@ -61,9 +60,7 @@ def read_model_metadata() -> list:
         }
         all_models_metadata.append(model_info)
 
-    all_models_metadata = sorted(
-        all_models_metadata, key=lambda x: x["downloaded"], reverse=True
-    )
+    all_models_metadata = sorted(all_models_metadata, key=lambda x: x["downloaded"], reverse=True)
 
     return all_models_metadata
 

--- a/aTrain/utils/transcription.py
+++ b/aTrain/utils/transcription.py
@@ -4,16 +4,15 @@ from multiprocessing import Manager
 from pathlib import Path
 from typing import TypedDict, cast
 
+from aTrain.components.dialogs.error import dialog_error
+from aTrain.components.dialogs.finished import dialog_finished
+from aTrain.components.dialogs.process import close_dialog_process, dialog_process
+from aTrain.utils.archive import delete_transcription
 from aTrain_core.settings import ComputeType, Device, Settings, check_inputs_transcribe
 from nicegui import app, events, run, ui
 from nicegui.run import SubprocessException
 from nicegui.run import setup as setup_process_pool
 from starlette.formparsers import MultiPartParser
-
-from aTrain.components.dialogs.error import dialog_error
-from aTrain.components.dialogs.finished import dialog_finished
-from aTrain.components.dialogs.process import close_dialog_process, dialog_process
-from aTrain.utils.archive import delete_transcription
 
 MultiPartParser.spool_max_size = 1024 * 1024 * 1024 * 10  # 10 GB file size limit
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,3 +52,8 @@ url = "https://download.pytorch.org/whl/cu128"
 torch       = [{ index = "pytorch-cu128", marker = "sys_platform == 'linux'" }]
 torchaudio  = [{ index = "pytorch-cu128", marker = "sys_platform == 'linux'" }]
 torchvision = [{ index = "pytorch-cu128", marker = "sys_platform == 'linux'" }]
+
+[dependency-groups]
+dev = [
+  "ruff>=0.15.0",
+]

--- a/uv.lock
+++ b/uv.lock
@@ -230,6 +230,11 @@ dependencies = [
     { name = "wakepy" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "ruff" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "atrain-core", git = "https://github.com/JuergenFleiss/atrain_core.git?rev=develop" },
@@ -241,6 +246,9 @@ requires-dist = [
     { name = "typer", specifier = "==0.16.0" },
     { name = "wakepy", specifier = "==0.7.2" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "ruff", specifier = ">=0.15.0" }]
 
 [[package]]
 name = "atrain-core"
@@ -3003,6 +3011,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/8a/8bce2894573e9dae6ff4d77fe34ad727d79b9e6238ad288c5638990d90f6/ruff-0.15.14.tar.gz", hash = "sha256:48e866b165be4a9bdbf310f7d3c9a07edef2fe8cd63ffeb4e00bb590506ebf9f", size = 4700910, upload-time = "2026-05-21T14:34:55.177Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/c8/74a92c6ff9fcfb4f1f947126d3ebee8389276e161ecc85de5bda7cda51bd/ruff-0.15.14-py3-none-linux_armv6l.whl", hash = "sha256:8dd2db9416e487c8d4b01fa7056bb02c4d05969d4f8d17a08c229c2f4ff3c108", size = 10739177, upload-time = "2026-05-21T14:34:37.332Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/254a35c20acc38a7223c9d2d594af12e794432464f2cdeb52af1dc4a892d/ruff-0.15.14-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:be4ff55af755bd71a00ab3dc6bd7ffc467bd76e0df6881e286c2e3d23e8fb43b", size = 11144969, upload-time = "2026-05-21T14:34:43.978Z" },
+    { url = "https://files.pythonhosted.org/packages/56/9e/d13e40f83b8d0a94430e6778ce1d94a43b38cf2efe63278bdd2b4c65abbf/ruff-0.15.14-py3-none-macosx_11_0_arm64.whl", hash = "sha256:48d5909d7d06276ce7dde6d32bfa4b0d4cb2651145cd8ee4b440722cbc77832f", size = 10478207, upload-time = "2026-05-21T14:34:48.378Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/f1/b15a7839fa4f332f8acec78e20564f26bb2d866e3d21710b877fd0263000/ruff-0.15.14-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca8cbfa94c4f90984a67561978602746d4cd27103568f745fa90eee3f0d4107d", size = 10818459, upload-time = "2026-05-21T14:34:22.318Z" },
+    { url = "https://files.pythonhosted.org/packages/45/33/53d651177f84f94b400a0e27f8824eeada3dddc9d5ee8aeb048f4352a520/ruff-0.15.14-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9a6bbc0333f1ab053423bcbf6226477d266ca7cec7738c4c8e3f55647803f3c4", size = 10541800, upload-time = "2026-05-21T14:34:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a6/868f87e0bf9786ed24b5d0d0ad8676b8a94fd1912f42cddf9cfc7857818a/ruff-0.15.14-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8a24a4f7605d7003a6674d4387651effd939dead3fddd0f36561eb77a9a2e542", size = 11342149, upload-time = "2026-05-21T14:34:46.365Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/8b/38cd5c19faffdcc05a408d2b78edccc69492ab9720eadb49ea15ef80d768/ruff-0.15.14-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:049b5326e53ed80978f2fc041a280603f69dd6b0c95464342a2bb4572d9d9e2f", size = 12212563, upload-time = "2026-05-21T14:34:28.579Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/4d/a3c5b874a556d5731e3e657aaf04311bb76f0a5c3ec220ed43051be6b64b/ruff-0.15.14-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4ed42e6696c8dfa5f06728e6441993901f548eb92d73bc472cb5a38d1395fbf", size = 11493299, upload-time = "2026-05-21T14:34:41.836Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c0/56472c251d09858a53e51efbd485b09e1995d8731668b76d52e5dd6ee0f1/ruff-0.15.14-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:715c543cf450c4888251f91c52f1942a800541d9bddd7ac060aa4e6b77ae7cba", size = 11455931, upload-time = "2026-05-21T14:34:57.276Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/4a/e2e7b4d8dbf233d4eace59c75bc3435fa6d8bd3bae82d351d4e4300c0fd1/ruff-0.15.14-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:72ebab6013ec887d439d8b7593737a0a4ffb06d45d209d4e4bf2e92813082d3f", size = 11400794, upload-time = "2026-05-21T14:34:39.773Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c7/83c0539fe34c3e09136204d1e75d6052492364e0b3cb05e9465423f567d7/ruff-0.15.14-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:49072d36abdbe97a8dd7f480afe9c675699c0c495d4c84076e2c1203c4550581", size = 10804759, upload-time = "2026-05-21T14:34:31.045Z" },
+    { url = "https://files.pythonhosted.org/packages/86/a6/18f2bfc095a2ab4a78745644e428205532ce6653a5d0fa8501572891534d/ruff-0.15.14-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:958522aee105068640c2c2ceae08f413ae44d922f52a1374ac13d6a96032fc93", size = 10539517, upload-time = "2026-05-21T14:34:53.064Z" },
+    { url = "https://files.pythonhosted.org/packages/54/3a/5a8b3b69c654d4e4bf1d246ac5b49cbcdac6eaab6905925f8915f31e3b80/ruff-0.15.14-py3-none-musllinux_1_2_i686.whl", hash = "sha256:f3707da619a143a2e8830e2abab8224478d69ace2d28cb6c20543ae97c36bf61", size = 11065169, upload-time = "2026-05-21T14:34:24.484Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/c5/8864e4e7925b836ea354b31d57641ec03830564e281a8b6f061f8c3e0ec1/ruff-0.15.14-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:bb01d645694e3ec0102105d07ef2d53703970407d59c04e59d3ba0b7a1d53553", size = 11560214, upload-time = "2026-05-21T14:34:50.975Z" },
+    { url = "https://files.pythonhosted.org/packages/36/38/012bf76752e1f89ed50b77b99532d90f3a3e287bc7918e1fc0948ac866ac/ruff-0.15.14-py3-none-win32.whl", hash = "sha256:6d0c1ad2a0ab718d39b6d8fd2217981ce4d625cd96a720095f798fb47d8b13e6", size = 10805548, upload-time = "2026-05-21T14:34:33.453Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b7/4ea2c170f10ad760fff2a5250beb18897719dc8b52b53a24cddbb9dd3f19/ruff-0.15.14-py3-none-win_amd64.whl", hash = "sha256:802342981e056db3851a7836e5b070f8f15f67d4a685ae2a6160939d364b2902", size = 11939523, upload-time = "2026-05-21T14:34:18.077Z" },
+    { url = "https://files.pythonhosted.org/packages/62/d5/bc97ff895ec35cf3925d4bd60f3b39d822f377a446906ec9bcc87405e59b/ruff-0.15.14-py3-none-win_arm64.whl", hash = "sha256:ff47b90a9ef6a40c9e2f3b479c1fb78531adf055b94c1eba0a7ba04b31951826", size = 11208607, upload-time = "2026-05-21T14:34:26.525Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds ruff (lint + format) as the first CI quality gate. Scope is
**ruff only** — `bandit` and `pip-audit` follow as separate PRs, each
its own CI job, per the review here.

Contributes to #158 (Task A — CI lint/format/security).

## Three commits

1. **`build: add ruff config (.ruff.toml) and dev dependency group`**
   — `ruff>=0.15.0` in `[dependency-groups] dev`; ruff config in its
   own `.ruff.toml` (not `pyproject.toml`, per review preference).
2. **`refactor: apply ruff auto-fixes`** — **only** auto-fixable
   findings (import sorting I001, UP015/UP035/UP045, RET505, the
   formatter). No behaviour-affecting edits.
3. **`ci: add ruff lint+format workflow`** — one `ruff` job, two
   steps (`ruff check .`, `ruff format --check .`).

## Addressing the review

- **Config in its own file**: ruff config now lives in `.ruff.toml`,
  keeping `pyproject.toml` from growing with dev-tool settings.
- **No risky manual edits**: the findings that need a manual
  (non-auto-fixable) change — `A001`/`A002` (builtin shadowing),
  `B904`, `RUF015`, `SIM118`, `S607` — are **not** changed in this
  PR. They are grandfathered via per-file-ignores in `.ruff.toml`
  (annotated, one file each) and deferred to small follow-up PRs that
  apply each fix alongside test coverage, so the behaviour change is
  reviewable in isolation. The rules stay enabled globally, so new
  code is still checked.

## CI install

The lint job installs **only ruff** (`uv sync --locked --only-group
dev --no-install-project`) — it doesn't build the app runtime
(torch, pywebview[GTK]). `--locked` still validates `uv.lock` against
`pyproject.toml`.

## Follow-ups (separate PRs)

- bandit security-scan job (Task A.2)
- pip-audit CVE-scan job (Task A.3)
- the grandfathered manual lint fixes, with tests
- app smoke-test job (#150) / WER quality (#147)

## Maps to BSI IT-Grundschutz

- CON.8 §3.2.5 (automated code analysis) — ruff covers the
  static-analysis half on every change.

cc @gerardo-navarro