### PR TITLE
Add GUI speaker voiceprints

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ aTrain provides a user friendly access to the [faster-whisper](https://github.co
 **Speaker detection 🗣️**
 \
 aTrain has a speaker detection mode based on [pyannote.audio](https://github.com/pyannote/pyannote-audio) and can analyze each text segment to determine which speaker it belongs to.
+The GUI can also enroll local speaker voiceprints from reference audio and use them to rename diarized speaker labels when a confident match is found.
 \
 \
 **Privacy Preservation and GDPR compliance 🔒**

--- a/aTrain/app.py
+++ b/aTrain/app.py
@@ -15,7 +15,7 @@ NICEGUI_STORAGE_PATH = user_config_path() / "aTrain" if FLATPAK else (ATRAIN_DIR
 with patch.dict(os.environ, NICEGUI_STORAGE_PATH=str(NICEGUI_STORAGE_PATH)):
     from nicegui import ui
 
-    from aTrain.pages import about, archive, faq, models, transcribe  # noqa
+    from aTrain.pages import about, archive, faq, models, transcribe, voiceprints  # noqa
 
 cli = Typer(help="CLI for aTrain.")
 

--- a/aTrain/components/layout/sidebar.py
+++ b/aTrain/components/layout/sidebar.py
@@ -6,6 +6,7 @@ def sidebar():
         nav_button(icon="🎧", text="Transcribe", path="/")
         nav_button(icon="💾", text="Archive", path="/archive")
         nav_button(icon="🧮", text="Models", path="/models")
+        nav_button(icon="🎙️", text="Voiceprints", path="/voiceprints")
         nav_button(icon="📖", text="FAQ", path="/faq")
         ui.separator()
         nav_button(icon="💡", text="About", path="/about")

--- a/aTrain/components/voiceprints/enroll_dialog.py
+++ b/aTrain/components/voiceprints/enroll_dialog.py
@@ -1,0 +1,99 @@
+from collections.abc import Callable
+from pathlib import Path
+from types import SimpleNamespace
+
+from aTrain.components.settings.file import input_file
+from aTrain.utils.voiceprints import enroll_voiceprint, show_voiceprint_error
+from aTrain.voiceprints import validate_voiceprint_name
+from aTrain_core.globals import FLATPAK
+from nicegui import events, ui
+
+
+def enroll_dialog(
+    existing_names: set[str],
+    on_success: Callable[[], None] | None = None,
+) -> None:
+    with ui.dialog(value=True) as dialog, ui.card().classes("w-[520px] p-8 gap-4"):
+        dialog.props("persistent")
+        ui.label("Enroll speaker voiceprint").classes("font-bold text-dark text-lg")
+        ui.separator()
+        name_input = ui.input("Name").classes("w-full")
+        name_error = ui.label("").classes("text-negative text-xs")
+        update_toggle = ui.checkbox("Update existing voiceprint")
+
+        with ui.column().classes("gap-2 w-full"):
+            ui.label("Reference audio").classes("font-bold text-dark text-sm")
+            uploader = input_file()
+
+        ui.label("Use a 10-30s clean clip recorded with a similar microphone.").classes(
+            "text-xs text-grey"
+        )
+        ui.separator()
+        with ui.row().classes("w-full justify-end"):
+            cancel_button = ui.button("Cancel", color="gray-100")
+            cancel_button.props("unelevated no-caps text-color=dark")
+            submit_button = ui.button("Enroll", color="dark")
+            submit_button.props("unelevated no-caps")
+
+    def validate_form() -> bool:
+        try:
+            cleaned = validate_voiceprint_name(name_input.value or "")
+        except ValueError as error:
+            name_error.set_text(str(error))
+            return False
+        if cleaned not in existing_names and update_toggle.value:
+            name_error.set_text("No existing voiceprint with this name.")
+            return False
+        name_error.set_text("")
+        return True
+
+    async def handle_upload(file_event: events.UploadEventArguments) -> None:
+        processing = _processing_dialog()
+        try:
+            await enroll_voiceprint(
+                file_event,
+                name=name_input.value or "",
+                update=bool(update_toggle.value),
+            )
+            processing.close()
+            dialog.close()
+            ui.notify("Voiceprint saved", type="positive")
+            if on_success is not None:
+                on_success()
+        except Exception as error:
+            processing.close()
+            show_voiceprint_error(error)
+
+    async def submit() -> None:
+        if not validate_form():
+            return
+        if FLATPAK:
+            selected_path = getattr(uploader, "selected_path", None)
+            if not selected_path:
+                ui.notify("Select a reference audio file first", type="warning")
+                return
+            payload = SimpleNamespace(
+                name=getattr(uploader, "selected_name", None) or Path(selected_path).name,
+                content=Path(selected_path),
+            )
+            await handle_upload(payload)
+            return
+        if getattr(uploader, "file_text", "") != "1 File Added":
+            ui.notify("Select a reference audio file first", type="warning")
+            return
+        uploader.upload()
+
+    name_input.on("update:model-value", lambda _: validate_form())
+    uploader.on_upload(handle_upload)
+    cancel_button.on_click(dialog.close)
+    submit_button.on_click(submit)
+
+
+def _processing_dialog():
+    with ui.dialog(value=True) as dialog, ui.card().classes("w-[420px] p-8 gap-3"):
+        dialog.props("persistent")
+        ui.label("Creating voiceprint").classes("font-bold text-dark text-lg")
+        ui.separator()
+        ui.spinner(size="lg", color="dark").classes("mx-auto")
+        ui.label("Extracting the speaker embedding...").classes("text-sm text-grey")
+    return dialog

--- a/aTrain/model_downloads.py
+++ b/aTrain/model_downloads.py
@@ -1,0 +1,15 @@
+from aTrain_core.globals import MODELS_DIR, REQUIRED_MODELS, REQUIRED_MODELS_DIR
+from aTrain_core.load_resources import load_model_config_file
+
+
+def check_model_downloaded(model: str) -> None:
+    available_models = load_model_config_file()
+    if model not in available_models:
+        raise ValueError(f"Model {model} is not available.")
+
+    models_dir = REQUIRED_MODELS_DIR if model in REQUIRED_MODELS else MODELS_DIR
+    model_path = models_dir / model
+    if not model_path.exists() or not any(model_path.rglob("*.bin")):
+        raise FileNotFoundError(
+            f"Model {model} is not downloaded. Download it from the Models page or run: aTrain init"
+        )

--- a/aTrain/pages/voiceprints.py
+++ b/aTrain/pages/voiceprints.py
@@ -1,0 +1,81 @@
+from aTrain.components.voiceprints.enroll_dialog import enroll_dialog
+from aTrain.layouts.base import base_layout
+from aTrain.utils.voiceprints import remove_voiceprint_async, show_voiceprint_error
+from aTrain.voiceprints import list_voiceprints
+from nicegui import ui
+
+
+@ui.page("/voiceprints")
+def page():
+    profiles = list_voiceprints()
+    with base_layout():
+        with ui.row().classes("w-full justify-between items-center"):
+            ui.label("Speaker voiceprints").classes("text-lg text-dark font-bold")
+            enroll_button = ui.button("Enroll new voiceprint", color="dark")
+            enroll_button.props("no-caps unelevated icon=record_voice_over")
+        ui.separator()
+
+        if not profiles:
+            with ui.column().classes("w-full items-center gap-3 py-12"):
+                ui.icon("record_voice_over").classes("text-5xl text-grey")
+                ui.label("No speaker voiceprints enrolled").classes("text-md text-grey")
+        else:
+            with ui.list().classes("w-full").props("separator"):
+                with ui.item():
+                    with ui.grid(columns="1.2fr 0.7fr 0.8fr 1.2fr 0.6fr") as grid:
+                        grid.classes("w-full text-grey text-xs items-end")
+                        ui.label("Name")
+                        ui.label("Dimension")
+                        ui.label("Enrollments")
+                        ui.label("Last enrolled")
+                        ui.label("Actions")
+                for profile in profiles:
+                    with ui.item().classes("hover:bg-gray-100"):
+                        with ui.grid(columns="1.2fr 0.7fr 0.8fr 1.2fr 0.6fr") as grid:
+                            grid.classes("w-full items-center gap-x-4")
+                            ui.label(profile.name).classes("font-medium")
+                            ui.label(str(profile.embedding_dim)).classes("font-light")
+                            ui.label(str(len(profile.enrollments))).classes("font-light")
+                            ui.label(_last_enrolled(profile.enrollments)).classes(
+                                "font-light text-xs"
+                            )
+                            delete_button = ui.button("Remove", color="gray-100")
+                            delete_button.props("no-caps size=0.7rem unelevated text-color=dark")
+                            delete_button.on_click(lambda name=profile.name: _confirm_remove(name))
+
+        enroll_button.on_click(
+            lambda: enroll_dialog(
+                {profile.name for profile in profiles},
+                on_success=ui.navigate.reload,
+            )
+        )
+
+
+def _last_enrolled(enrollments: list[dict]) -> str:
+    if not enrollments:
+        return "-"
+    return str(enrollments[-1].get("enrolled_at", "-"))
+
+
+def _confirm_remove(name: str) -> None:
+    with ui.dialog(value=True) as dialog, ui.card().classes("p-8 gap-3"):
+        dialog.props("persistent")
+        ui.label(f"Remove voiceprint {name}?").classes("font-bold text-dark")
+        ui.separator()
+        with ui.row().classes("w-full justify-end"):
+            cancel_button = ui.button("Cancel", color="gray-100")
+            cancel_button.props("unelevated no-caps text-color=dark")
+            confirm_button = ui.button("Confirm", color="dark")
+            confirm_button.props("unelevated no-caps")
+
+    async def remove_and_reload() -> None:
+        try:
+            await remove_voiceprint_async(name)
+            dialog.close()
+            ui.navigate.reload()
+        except Exception as error:
+            dialog.close()
+            show_voiceprint_error(error)
+
+    cancel_button.on_click(dialog.close)
+    confirm_button.on_click(remove_and_reload)

--- a/aTrain/utils/transcription.py
+++ b/aTrain/utils/transcription.py
@@ -4,10 +4,12 @@ from multiprocessing import Manager
 from pathlib import Path
 from typing import TypedDict, cast
 
+import numpy as np
 from aTrain.components.dialogs.error import dialog_error
 from aTrain.components.dialogs.finished import dialog_finished
 from aTrain.components.dialogs.process import close_dialog_process, dialog_process
 from aTrain.utils.archive import delete_transcription
+from aTrain_core import outputs as core_outputs
 from aTrain_core.settings import ComputeType, Device, Settings, check_inputs_transcribe
 from nicegui import app, events, run, ui
 from nicegui.run import SubprocessException
@@ -29,9 +31,13 @@ class State(TypedDict):
     cpu_threads: int
 
 
+VOICEPRINT_THRESHOLD = 0.5
+VOICEPRINT_MARGIN = 0.05
+
+
 async def start_transcription(file: events.UploadEventArguments):
     # Lazy import for improved startup speed
-    from aTrain_core.transcribe import prepare_transcription, transcribe
+    from aTrain_core.transcribe import prepare_transcription
 
     with Manager() as manager:
         progress = manager.dict({"task": "Prepare", "current": 0, "total": 999999})
@@ -58,7 +64,7 @@ async def start_transcription(file: events.UploadEventArguments):
             check_inputs_transcribe(
                 settings.file_name, settings.model, settings.language, settings.device
             )
-            await run.cpu_bound(transcribe, settings=settings)
+            await run.cpu_bound(transcribe_with_voiceprints, settings=settings)
             close_dialog_process()
             dialog_finished(file_id)
 
@@ -75,3 +81,94 @@ async def start_transcription(file: events.UploadEventArguments):
         except Exception as e:
             close_dialog_process()
             dialog_error(error=str(e), traceback=traceback.format_exc())
+
+
+def transcribe_with_voiceprints(settings: Settings) -> None:
+    profiles = _list_voiceprints() if settings.speaker_detection else []
+    if not profiles:
+        _transcribe_core(settings)
+        return
+
+    with _patch_core_speaker_capture():
+        _transcribe_core(settings)
+    _apply_voiceprint_identification_to_output(settings.file_id, profiles)
+
+
+def _apply_voiceprint_identification_to_output(file_id: str, profiles: list) -> None:
+    captured = _read_captured_embeddings(Path(core_outputs.TRANSCRIPT_DIR), file_id)
+    if captured is None:
+        core_outputs.write_logfile("No speaker embeddings captured for voiceprints", file_id)
+        return
+
+    labels, embeddings = captured
+    if not labels or not isinstance(embeddings, np.ndarray) or embeddings.size == 0:
+        return
+
+    scores = _cosine_similarity_matrix(embeddings, profiles)
+    speaker_map = _assign_voiceprints(
+        scores,
+        labels,
+        [profile.name for profile in profiles],
+        VOICEPRINT_THRESHOLD,
+        VOICEPRINT_MARGIN,
+    )
+    if not speaker_map:
+        core_outputs.write_logfile("No voiceprint matches above threshold", file_id)
+        return
+
+    transcript_path = Path(core_outputs.TRANSCRIPT_DIR) / file_id / "transcription.json"
+    import json
+
+    with transcript_path.open("r", encoding="utf-8") as handle:
+        transcript = json.load(handle)
+    _apply_speaker_map_to_transcript(transcript, speaker_map)
+    core_outputs.create_output_files(transcript, True, file_id)
+    core_outputs.write_logfile(f"Applied voiceprint speaker map: {speaker_map}", file_id)
+
+
+def _transcribe_core(settings: Settings) -> None:
+    from aTrain_core.transcribe import transcribe
+
+    transcribe(settings)
+
+
+def _list_voiceprints():
+    from aTrain.voiceprints import list_voiceprints
+
+    return list_voiceprints()
+
+
+def _patch_core_speaker_capture():
+    from aTrain.voiceprint_identification import patch_core_speaker_capture
+
+    return patch_core_speaker_capture()
+
+
+def _read_captured_embeddings(staging_dir: Path, file_id: str):
+    from aTrain.voiceprint_identification import read_captured_embeddings
+
+    return read_captured_embeddings(staging_dir, file_id)
+
+
+def _cosine_similarity_matrix(embeddings: np.ndarray, profiles: list):
+    from aTrain.voiceprints import cosine_similarity_matrix
+
+    return cosine_similarity_matrix(embeddings, profiles)
+
+
+def _assign_voiceprints(
+    scores: np.ndarray,
+    labels: list[str],
+    names: list[str],
+    threshold: float,
+    margin: float,
+):
+    from aTrain.voiceprints import assign_voiceprints
+
+    return assign_voiceprints(scores, labels, names, threshold, margin)
+
+
+def _apply_speaker_map_to_transcript(transcript: dict, speaker_map: dict[str, str]) -> None:
+    from aTrain.voiceprints import apply_speaker_map_to_transcript
+
+    apply_speaker_map_to_transcript(transcript, speaker_map)

--- a/aTrain/utils/voiceprints.py
+++ b/aTrain/utils/voiceprints.py
@@ -1,0 +1,120 @@
+import shutil
+import tempfile
+import traceback
+from datetime import UTC, datetime
+from pathlib import Path
+
+from aTrain.model_downloads import check_model_downloaded
+from aTrain.voiceprints import (
+    EMBEDDING_MODEL_ID,
+    VOICEPRINT_SCHEMA_VERSION,
+    VoiceprintProfile,
+    load_voiceprint,
+    merge_centroid,
+    remove_voiceprint,
+    save_voiceprint,
+    validate_voiceprint_name,
+)
+from aTrain_core.globals import SAMPLING_RATE
+from aTrain_core.load_resources import get_model
+from nicegui import app, events, run
+from nicegui.run import SubprocessException
+
+
+async def enroll_voiceprint(
+    file_event: events.UploadEventArguments, name: str, update: bool
+) -> None:
+    cleaned_name = validate_voiceprint_name(name)
+    check_model_downloaded("speaker-detection")
+
+    tmp_path: Path | None = None
+    try:
+        suffix = Path(file_event.name).suffix
+        with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as temp_file:
+            tmp_path = Path(temp_file.name)
+            if isinstance(file_event.content, Path):
+                temp_file.close()
+                shutil.copy2(file_event.content, tmp_path)
+            else:
+                temp_file.write(file_event.content.read())
+
+        model_path = get_model("speaker-detection")
+        duration_sec = _audio_duration_sec(tmp_path)
+        device = _enrollment_device()
+        from aTrain.voiceprint_identification import extract_embedding
+
+        embedding = await run.cpu_bound(
+            extract_embedding,
+            audio_path=tmp_path,
+            model_path=model_path,
+            device=device,
+            min_duration_sec=3.0,
+        )
+
+        enrollment = {
+            "source": file_event.name,
+            "duration_sec": round(duration_sec, 2),
+            "enrolled_at": datetime.now(UTC).isoformat(),
+        }
+        try:
+            existing = load_voiceprint(cleaned_name)
+        except FileNotFoundError:
+            existing = None
+
+        if existing is not None and not update:
+            raise FileExistsError(
+                f"Voiceprint {cleaned_name} already exists. Enable update to add another enrollment."
+            )
+        if existing is None:
+            profile = VoiceprintProfile(
+                name=cleaned_name,
+                model_id=EMBEDDING_MODEL_ID,
+                schema_version=VOICEPRINT_SCHEMA_VERSION,
+                embedding_dim=int(embedding.shape[0]),
+                embedding=embedding,
+                enrollments=[enrollment],
+            )
+        else:
+            profile = VoiceprintProfile(
+                name=existing.name,
+                model_id=existing.model_id,
+                schema_version=existing.schema_version,
+                embedding_dim=existing.embedding_dim,
+                embedding=merge_centroid(
+                    existing.embedding,
+                    embedding,
+                    existing_count=max(len(existing.enrollments), 1),
+                ),
+                enrollments=[*existing.enrollments, enrollment],
+            )
+        save_voiceprint(profile)
+    finally:
+        if tmp_path is not None and tmp_path.exists():
+            tmp_path.unlink(missing_ok=True)
+
+
+async def remove_voiceprint_async(name: str) -> None:
+    remove_voiceprint(name)
+
+
+def show_voiceprint_error(error: Exception) -> None:
+    from aTrain.components.dialogs.error import dialog_error
+
+    if isinstance(error, SubprocessException):
+        dialog_error(error=error.original_message, traceback=error.original_traceback)
+    else:
+        dialog_error(error=str(error), traceback=traceback.format_exc())
+
+
+def _audio_duration_sec(audio_path: Path) -> float:
+    from faster_whisper.audio import decode_audio
+
+    audio_array = decode_audio(str(audio_path), sampling_rate=SAMPLING_RATE)
+    return len(audio_array) / SAMPLING_RATE
+
+
+def _enrollment_device():
+    import torch
+
+    use_gpu = bool(app.storage.general.get("GPU", False))
+    return torch.device("cuda" if use_gpu else "cpu")

--- a/aTrain/voiceprint_identification.py
+++ b/aTrain/voiceprint_identification.py
@@ -1,0 +1,141 @@
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+import numpy as np
+from aTrain_core import outputs as core_outputs
+from aTrain_core.globals import SAMPLING_RATE
+from aTrain_core.load_resources import get_model
+from aTrain_core.outputs import (
+    assign_word_speakers,
+    transform_speakers_results,
+    write_logfile,
+)
+from aTrain_core.settings import Device, Settings
+
+from aTrain.voiceprints import _l2_normalise_vector
+
+CAPTURE_FILENAME = "_speaker_embeddings.npz"
+
+
+def extract_embedding(
+    audio_path: Path,
+    model_path: Path,
+    device,
+    min_duration_sec: float = 3.0,
+) -> np.ndarray:
+    audio_array = _decode_audio(str(audio_path), sampling_rate=SAMPLING_RATE)
+    duration_sec = len(audio_array) / SAMPLING_RATE
+    if duration_sec < min_duration_sec:
+        raise ValueError(
+            f"Voiceprint enrollment audio must be at least {min_duration_sec:.1f} seconds."
+        )
+
+    import torch
+
+    embedding_model = _pretrained_speaker_embedding(str(model_path / "embedding"), device=device)
+    waveform = torch.from_numpy(audio_array.astype(np.float32)[None, None, :])
+    embedding = embedding_model(waveform)
+    if hasattr(embedding, "detach"):
+        embedding = embedding.detach().cpu().numpy()
+    embedding_array = np.asarray(embedding, dtype=np.float32)
+    if embedding_array.ndim == 2:
+        embedding_array = embedding_array[0]
+    return _l2_normalise_vector(embedding_array).astype(np.float32)
+
+
+def run_speaker_detection_with_capture(
+    settings: Settings, audio_duration: int, audio_array: np.ndarray, transcript: dict
+) -> dict:
+    """Run speaker detection and capture embeddings.
+
+    This mirrors aTrain_core release_v1.4.2's run_speaker_detection implementation
+    and additionally stores DiarizeOutput.speaker_embeddings in the staging
+    transcript directory for CLI identity post-processing.
+    """
+    import torch
+
+    model_path = get_model("speaker-detection")
+    write_logfile("Speaker detection model loaded", settings.file_id)
+    audio = {
+        "waveform": torch.from_numpy(audio_array[None, :]),
+        "sample_rate": SAMPLING_RATE,
+    }
+    pipeline = _pipeline_from_pretrained(model_path)
+    if not pipeline:
+        raise Exception("Failed to initialize speaker detection pipeline!")
+    write_logfile("Detecting speakers", settings.file_id)
+
+    if settings.device == Device.GPU:
+        pipeline.to(torch.device("cuda"))
+
+    with _custom_progress_hook(settings.progress) as hook:
+        output = pipeline(audio, num_speakers=settings.speaker_count, hook=hook)
+
+    _write_captured_embeddings(settings.file_id, output)
+    segments = output.speaker_diarization
+    speaker_results = transform_speakers_results(segments)
+    write_logfile("Transformed diarization segments", settings.file_id)
+    transcript_with_speaker = assign_word_speakers(speaker_results, transcript)
+    write_logfile("Assigned speakers to words", settings.file_id)
+    return transcript_with_speaker
+
+
+@contextmanager
+def patch_core_speaker_capture() -> Iterator[None]:
+    import aTrain_core.transcribe as core_transcribe
+
+    original = core_transcribe.run_speaker_detection
+    core_transcribe.run_speaker_detection = run_speaker_detection_with_capture
+    try:
+        yield
+    finally:
+        core_transcribe.run_speaker_detection = original
+
+
+def read_captured_embeddings(
+    staging_dir: Path, file_id: str
+) -> tuple[list[str], np.ndarray] | None:
+    path = staging_dir / file_id / CAPTURE_FILENAME
+    if not path.exists():
+        return None
+    with np.load(path, allow_pickle=False) as data:
+        labels = [str(label) for label in data["labels"].tolist()]
+        embeddings = np.asarray(data["embeddings"], dtype=np.float32)
+    return labels, embeddings
+
+
+def _write_captured_embeddings(file_id: str, output) -> None:
+    labels = [str(label) for label in output.speaker_diarization.labels()]
+    embeddings = np.asarray(output.speaker_embeddings, dtype=np.float32)
+    target_dir = Path(core_outputs.TRANSCRIPT_DIR) / file_id
+    target_dir.mkdir(parents=True, exist_ok=True)
+    np.savez_compressed(
+        target_dir / CAPTURE_FILENAME,
+        labels=np.asarray(labels),
+        embeddings=embeddings,
+    )
+
+
+def _decode_audio(path: str, sampling_rate: int) -> np.ndarray:
+    from faster_whisper.audio import decode_audio
+
+    return decode_audio(path, sampling_rate=sampling_rate)
+
+
+def _pretrained_speaker_embedding(embedding: str, device):
+    from pyannote.audio.pipelines.speaker_verification import PretrainedSpeakerEmbedding
+
+    return PretrainedSpeakerEmbedding(embedding, device=device)
+
+
+def _pipeline_from_pretrained(model_path: Path):
+    from pyannote.audio import Pipeline
+
+    return Pipeline.from_pretrained(model_path)
+
+
+def _custom_progress_hook(progress):
+    from aTrain_core.transcribe import CustomProgressHook
+
+    return CustomProgressHook(progress)

--- a/aTrain/voiceprints.py
+++ b/aTrain/voiceprints.py
@@ -1,0 +1,200 @@
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from aTrain_core.globals import ATRAIN_DIR
+from scipy.optimize import linear_sum_assignment
+
+VOICEPRINTS_DIR = ATRAIN_DIR / "voiceprints"
+VOICEPRINT_SCHEMA_VERSION = 1
+EMBEDDING_MODEL_ID = "speaker-detection/embedding"
+LOGGER = logging.getLogger(__name__)
+
+_INVALID_NAME_CHARS = set('<>:"/\\|?*')
+
+
+@dataclass
+class VoiceprintProfile:
+    name: str
+    model_id: str
+    schema_version: int
+    embedding_dim: int
+    embedding: np.ndarray
+    enrollments: list[dict[str, Any]] = field(default_factory=list)
+
+
+def validate_voiceprint_name(name: str) -> str:
+    cleaned = name.strip()
+    if not cleaned:
+        raise ValueError("Voiceprint name cannot be empty.")
+    if len(cleaned) > 64:
+        raise ValueError("Voiceprint name must be 64 characters or fewer.")
+    if any(char in _INVALID_NAME_CHARS for char in cleaned):
+        raise ValueError("Voiceprint name cannot contain path or Windows-reserved characters.")
+    return cleaned
+
+
+def voiceprint_path(name: str) -> Path:
+    return VOICEPRINTS_DIR / f"{validate_voiceprint_name(name)}.json"
+
+
+def load_voiceprint(name: str) -> VoiceprintProfile:
+    path = voiceprint_path(name)
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    return _profile_from_payload(payload, path)
+
+
+def save_voiceprint(profile: VoiceprintProfile) -> None:
+    name = validate_voiceprint_name(profile.name)
+    embedding = _l2_normalise_vector(profile.embedding)
+    embedding_dim = int(embedding.shape[0])
+    VOICEPRINTS_DIR.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema_version": VOICEPRINT_SCHEMA_VERSION,
+        "name": name,
+        "model_id": profile.model_id,
+        "embedding_dim": embedding_dim,
+        "embedding": embedding.tolist(),
+        "enrollments": list(profile.enrollments),
+    }
+    path = voiceprint_path(name)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False, indent=2)
+
+
+def list_voiceprints() -> list[VoiceprintProfile]:
+    if not VOICEPRINTS_DIR.exists():
+        return []
+
+    profiles: list[VoiceprintProfile] = []
+    for path in sorted(VOICEPRINTS_DIR.glob("*.json"), key=lambda item: item.stem.lower()):
+        try:
+            with path.open("r", encoding="utf-8") as handle:
+                profiles.append(_profile_from_payload(json.load(handle), path))
+        except Exception as error:
+            LOGGER.warning("Skipping invalid voiceprint profile %s: %s", path, error)
+            continue
+    return sorted(profiles, key=lambda profile: profile.name.lower())
+
+
+def remove_voiceprint(name: str) -> None:
+    path = voiceprint_path(name)
+    if not path.exists():
+        raise FileNotFoundError(f"Voiceprint does not exist: {name}")
+    path.unlink()
+
+
+def merge_centroid(existing: np.ndarray, new: np.ndarray, existing_count: int) -> np.ndarray:
+    if existing_count < 1:
+        raise ValueError("existing_count must be at least 1.")
+    existing_vector = np.asarray(existing, dtype=np.float32)
+    new_vector = np.asarray(new, dtype=np.float32)
+    if existing_vector.shape != new_vector.shape:
+        raise ValueError("Embeddings must have the same shape.")
+    return ((existing_vector * existing_count) + new_vector) / (existing_count + 1)
+
+
+def cosine_similarity_matrix(
+    speaker_centroids: np.ndarray, voiceprints: list[VoiceprintProfile]
+) -> np.ndarray:
+    centroids = np.asarray(speaker_centroids, dtype=np.float32)
+    if centroids.size == 0 or not voiceprints:
+        return np.empty((centroids.shape[0] if centroids.ndim == 2 else 0, 0), dtype=np.float32)
+    if centroids.ndim != 2:
+        raise ValueError("speaker_centroids must be a 2-D array.")
+
+    centroid_matrix = _l2_normalise_matrix(centroids)
+    voiceprint_matrix = _l2_normalise_matrix(
+        np.vstack([np.asarray(profile.embedding, dtype=np.float32) for profile in voiceprints])
+    )
+    return centroid_matrix @ voiceprint_matrix.T
+
+
+def assign_voiceprints(
+    scores: np.ndarray,
+    speaker_labels: list[str],
+    voiceprint_names: list[str],
+    threshold: float,
+    margin: float,
+) -> dict[str, str]:
+    score_matrix = np.asarray(scores, dtype=np.float32)
+    if score_matrix.size == 0 or not speaker_labels or not voiceprint_names:
+        return {}
+    if score_matrix.shape != (len(speaker_labels), len(voiceprint_names)):
+        raise ValueError("scores shape must match speaker_labels and voiceprint_names.")
+
+    rows, columns = linear_sum_assignment(-score_matrix)
+    assignments: dict[str, str] = {}
+    for row, column in zip(rows, columns, strict=True):
+        score = float(score_matrix[row, column])
+        if score < threshold:
+            continue
+        if score - _best_competing_score(score_matrix, row, column) < margin:
+            continue
+        assignments[speaker_labels[row]] = voiceprint_names[column]
+    return assignments
+
+
+def apply_speaker_map_to_transcript(transcript: dict, speaker_map: dict[str, str]) -> None:
+    if not speaker_map:
+        return
+    for segment in transcript.get("segments", []):
+        if segment.get("speaker") in speaker_map:
+            segment["speaker"] = speaker_map[segment["speaker"]]
+        for word in segment.get("words", []):
+            if word.get("speaker") in speaker_map:
+                word["speaker"] = speaker_map[word["speaker"]]
+
+
+def _profile_from_payload(payload: dict[str, Any], path: Path) -> VoiceprintProfile:
+    if payload.get("schema_version") != VOICEPRINT_SCHEMA_VERSION:
+        raise ValueError(f"Unsupported voiceprint schema in {path}")
+    if payload.get("model_id") != EMBEDDING_MODEL_ID:
+        raise ValueError(f"Unsupported voiceprint model in {path}")
+
+    name = validate_voiceprint_name(str(payload["name"]))
+    embedding = np.asarray(payload["embedding"], dtype=np.float32)
+    if embedding.ndim != 1:
+        raise ValueError(f"Voiceprint embedding must be one-dimensional: {path}")
+    embedding_dim = int(payload["embedding_dim"])
+    if embedding.shape[0] != embedding_dim:
+        raise ValueError(f"Voiceprint embedding_dim does not match embedding length: {path}")
+    return VoiceprintProfile(
+        name=name,
+        model_id=EMBEDDING_MODEL_ID,
+        schema_version=VOICEPRINT_SCHEMA_VERSION,
+        embedding_dim=embedding_dim,
+        embedding=_l2_normalise_vector(embedding),
+        enrollments=list(payload.get("enrollments", [])),
+    )
+
+
+def _l2_normalise_vector(vector: np.ndarray) -> np.ndarray:
+    array = np.asarray(vector, dtype=np.float32).reshape(-1)
+    norm = float(np.linalg.norm(array))
+    if norm == 0.0:
+        raise ValueError("Embedding cannot be a zero vector.")
+    return array / norm
+
+
+def _l2_normalise_matrix(matrix: np.ndarray) -> np.ndarray:
+    array = np.asarray(matrix, dtype=np.float32)
+    norms = np.linalg.norm(array, axis=1, keepdims=True)
+    if np.any(norms == 0):
+        raise ValueError("Embedding matrix cannot contain zero vectors.")
+    return array / norms
+
+
+def _best_competing_score(scores: np.ndarray, row: int, column: int) -> float:
+    competitors: list[float] = []
+    if scores.shape[1] > 1:
+        competitors.append(float(np.max(np.delete(scores[row, :], column))))
+    if scores.shape[0] > 1:
+        competitors.append(float(np.max(np.delete(scores[:, column], row))))
+    if not competitors:
+        return float("-inf")
+    return max(competitors)

--- a/tests/test_gui_voiceprint_identification.py
+++ b/tests/test_gui_voiceprint_identification.py
@@ -1,0 +1,156 @@
+import json
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import numpy as np
+from aTrain.voiceprints import EMBEDDING_MODEL_ID, VoiceprintProfile
+
+
+class GuiVoiceprintIdentificationTests(unittest.TestCase):
+    def test_transcribe_with_voiceprints_captures_and_rewrites_gui_outputs(self):
+        from aTrain.utils.transcription import transcribe_with_voiceprints
+
+        settings = types.SimpleNamespace(file_id="file-id", speaker_detection=True)
+        profile = VoiceprintProfile(
+            name="Ray",
+            model_id=EMBEDDING_MODEL_ID,
+            schema_version=1,
+            embedding_dim=2,
+            embedding=np.array([1.0, 0.0], dtype=np.float32),
+            enrollments=[],
+        )
+        capture_context = CaptureContext()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            transcript_dir = Path(temp_dir) / "file-id"
+            transcript_dir.mkdir()
+            (transcript_dir / "transcription.json").write_text(
+                json.dumps(
+                    {
+                        "segments": [
+                            {
+                                "speaker": "SPEAKER_00",
+                                "text": "hello",
+                                "words": [{"speaker": "SPEAKER_00", "word": "hello"}],
+                            }
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with (
+                mock.patch(
+                    "aTrain.utils.transcription.core_outputs.TRANSCRIPT_DIR",
+                    temp_dir,
+                ),
+                mock.patch(
+                    "aTrain.utils.transcription._list_voiceprints",
+                    return_value=[profile],
+                ),
+                mock.patch(
+                    "aTrain.utils.transcription._patch_core_speaker_capture",
+                    return_value=capture_context,
+                ),
+                mock.patch("aTrain.utils.transcription._transcribe_core") as transcribe,
+                mock.patch(
+                    "aTrain.utils.transcription._read_captured_embeddings",
+                    return_value=(["SPEAKER_00"], np.array([[1.0, 0.0]], dtype=np.float32)),
+                ),
+                mock.patch(
+                    "aTrain.utils.transcription._cosine_similarity_matrix",
+                    return_value=np.array([[0.9]], dtype=np.float32),
+                ),
+                mock.patch(
+                    "aTrain.utils.transcription._assign_voiceprints",
+                    return_value={"SPEAKER_00": "Ray"},
+                ),
+                mock.patch(
+                    "aTrain.utils.transcription.core_outputs.create_output_files"
+                ) as create_output_files,
+                mock.patch("aTrain.utils.transcription.core_outputs.write_logfile"),
+            ):
+                transcribe_with_voiceprints(settings)
+
+        transcribe.assert_called_once_with(settings)
+        self.assertTrue(capture_context.entered)
+        self.assertTrue(capture_context.exited)
+        create_output_files.assert_called_once()
+        transcript = create_output_files.call_args.args[0]
+        self.assertEqual(transcript["segments"][0]["speaker"], "Ray")
+        self.assertEqual(transcript["segments"][0]["words"][0]["speaker"], "Ray")
+
+    def test_transcribe_with_voiceprints_noops_when_gui_has_no_voiceprints(self):
+        from aTrain.utils.transcription import transcribe_with_voiceprints
+
+        settings = types.SimpleNamespace(file_id="file-id", speaker_detection=True)
+
+        with (
+            mock.patch(
+                "aTrain.utils.transcription._list_voiceprints",
+                return_value=[],
+            ),
+            mock.patch("aTrain.utils.transcription._patch_core_speaker_capture") as patch_capture,
+            mock.patch("aTrain.utils.transcription._transcribe_core") as transcribe,
+        ):
+            transcribe_with_voiceprints(settings)
+
+        transcribe.assert_called_once_with(settings)
+        patch_capture.assert_not_called()
+
+
+class GuiVoiceprintEnrollmentTests(unittest.IsolatedAsyncioTestCase):
+    async def test_enroll_voiceprint_accepts_flatpak_selected_path_content(self):
+        from aTrain.utils.voiceprints import enroll_voiceprint
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            audio_path = Path(temp_dir) / "reference.wav"
+            audio_path.write_bytes(b"reference audio")
+            event = types.SimpleNamespace(name="reference.wav", content=audio_path)
+            saved = {}
+
+            async def fake_cpu_bound(_func, **kwargs):
+                copied_path = kwargs["audio_path"]
+                self.assertTrue(copied_path.exists())
+                self.assertEqual(copied_path.read_bytes(), b"reference audio")
+                return np.array([1.0, 0.0], dtype=np.float32)
+
+            with (
+                mock.patch("aTrain.utils.voiceprints.check_model_downloaded"),
+                mock.patch(
+                    "aTrain.utils.voiceprints.get_model", return_value=Path("speaker-detection")
+                ),
+                mock.patch("aTrain.utils.voiceprints._audio_duration_sec", return_value=4.0),
+                mock.patch("aTrain.utils.voiceprints._enrollment_device", return_value=object()),
+                mock.patch("aTrain.utils.voiceprints.run.cpu_bound", side_effect=fake_cpu_bound),
+                mock.patch(
+                    "aTrain.utils.voiceprints.load_voiceprint", side_effect=FileNotFoundError
+                ),
+                mock.patch(
+                    "aTrain.utils.voiceprints.save_voiceprint",
+                    side_effect=lambda profile: saved.setdefault("profile", profile),
+                ),
+            ):
+                await enroll_voiceprint(event, name="Ray", update=False)
+
+        profile = saved["profile"]
+        self.assertEqual(profile.name, "Ray")
+        self.assertEqual(profile.embedding_dim, 2)
+        self.assertTrue(np.allclose(profile.embedding, np.array([1.0, 0.0], dtype=np.float32)))
+        self.assertEqual(profile.enrollments[0]["source"], "reference.wav")
+
+
+class CaptureContext:
+    def __init__(self):
+        self.entered = False
+        self.exited = False
+
+    def __enter__(self):
+        self.entered = True
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.exited = True

--- a/tests/test_voiceprint_identification.py
+++ b/tests/test_voiceprint_identification.py
@@ -1,0 +1,138 @@
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import aTrain.voiceprint_identification as voiceprint_identification
+import numpy as np
+from aTrain_core.globals import SAMPLING_RATE
+from aTrain_core.settings import Device
+
+
+class VoiceprintIdentificationTests(unittest.TestCase):
+    def test_extract_embedding_calls_pretrained_with_local_path_and_returns_normalised(self):
+        device = object()
+        embedding_fn = mock.Mock(return_value=np.array([[3.0, 4.0]], dtype=np.float32))
+
+        with (
+            mock.patch(
+                "aTrain.voiceprint_identification._decode_audio",
+                return_value=np.ones(SAMPLING_RATE * 4, dtype=np.float32),
+            ),
+            mock.patch(
+                "aTrain.voiceprint_identification._pretrained_speaker_embedding",
+                return_value=embedding_fn,
+            ) as embedding_factory,
+        ):
+            result = voiceprint_identification.extract_embedding(
+                Path("ray.wav"), Path("speaker-detection"), device=device
+            )
+
+        embedding_factory.assert_called_once_with(
+            str(Path("speaker-detection") / "embedding"), device=device
+        )
+        self.assertTrue(np.allclose(result, np.array([0.6, 0.8], dtype=np.float32)))
+        self.assertEqual(result.dtype, np.float32)
+
+    def test_extract_embedding_raises_on_too_short_audio(self):
+        with (
+            mock.patch(
+                "aTrain.voiceprint_identification._decode_audio",
+                return_value=np.ones(SAMPLING_RATE * 2, dtype=np.float32),
+            ),
+            self.assertRaisesRegex(ValueError, "at least 3.0 seconds"),
+        ):
+            voiceprint_identification.extract_embedding(
+                Path("short.wav"), Path("speaker-detection"), device=object()
+            )
+
+    def test_patch_core_speaker_capture_restores_original(self):
+        import aTrain_core.transcribe as core_transcribe
+
+        original = core_transcribe.run_speaker_detection
+        with voiceprint_identification.patch_core_speaker_capture():
+            self.assertIsNot(core_transcribe.run_speaker_detection, original)
+
+        self.assertIs(core_transcribe.run_speaker_detection, original)
+
+    def test_patch_core_speaker_capture_restores_on_exception(self):
+        import aTrain_core.transcribe as core_transcribe
+
+        original = core_transcribe.run_speaker_detection
+        with (
+            self.assertRaises(RuntimeError),
+            voiceprint_identification.patch_core_speaker_capture(),
+        ):
+            raise RuntimeError("boom")
+
+        self.assertIs(core_transcribe.run_speaker_detection, original)
+
+    def test_run_speaker_detection_with_capture_writes_npz(self):
+        settings = types.SimpleNamespace(
+            file_id="file-id",
+            speaker_count=None,
+            device=Device.CPU,
+            progress={},
+        )
+        transcript = {"segments": [{"start": 0.0, "end": 1.0, "text": "hello"}]}
+        fake_output = types.SimpleNamespace(
+            speaker_diarization=FakeDiarization(["SPEAKER_00", "SPEAKER_01"]),
+            speaker_embeddings=np.array([[1.0, 0.0], [0.0, 1.0]], dtype=np.float32),
+        )
+        fake_pipeline = mock.Mock(return_value=fake_output)
+        expected_transcript = {"segments": [{"speaker": "SPEAKER_00"}]}
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            (Path(temp_dir) / "file-id").mkdir()
+            with (
+                mock.patch(
+                    "aTrain.voiceprint_identification.core_outputs.TRANSCRIPT_DIR",
+                    temp_dir,
+                ),
+                mock.patch(
+                    "aTrain.voiceprint_identification.get_model",
+                    return_value=Path("speaker-detection"),
+                ),
+                mock.patch(
+                    "aTrain.voiceprint_identification._pipeline_from_pretrained",
+                    return_value=fake_pipeline,
+                ),
+                mock.patch("aTrain.voiceprint_identification.write_logfile"),
+                mock.patch(
+                    "aTrain.voiceprint_identification.transform_speakers_results",
+                    return_value="speaker-results",
+                ),
+                mock.patch(
+                    "aTrain.voiceprint_identification.assign_word_speakers",
+                    return_value=expected_transcript,
+                ),
+            ):
+                result = voiceprint_identification.run_speaker_detection_with_capture(
+                    settings,
+                    audio_duration=1,
+                    audio_array=np.ones(SAMPLING_RATE, dtype=np.float32),
+                    transcript=transcript,
+                )
+
+            with np.load(Path(temp_dir) / "file-id" / "_speaker_embeddings.npz") as captured:
+                labels = captured["labels"].tolist()
+                embeddings_shape = captured["embeddings"].shape
+
+        self.assertEqual(result, expected_transcript)
+        self.assertEqual(labels, ["SPEAKER_00", "SPEAKER_01"])
+        self.assertEqual(embeddings_shape, (2, 2))
+
+    def test_read_captured_embeddings_returns_none_when_missing(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            result = voiceprint_identification.read_captured_embeddings(Path(temp_dir), "missing")
+
+        self.assertIsNone(result)
+
+
+class FakeDiarization:
+    def __init__(self, labels):
+        self._labels = labels
+
+    def labels(self):
+        return self._labels

--- a/tests/test_voiceprints.py
+++ b/tests/test_voiceprints.py
@@ -1,0 +1,220 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import aTrain.voiceprints as voiceprints
+import numpy as np
+from aTrain.voiceprints import VoiceprintProfile
+
+
+class VoiceprintTests(unittest.TestCase):
+    def test_validate_voiceprint_name_rejects_path_separators_blank_and_overlong(self):
+        invalid_names = ["", "   ", "Ray/Alice", "Ray\\Alice", "Bad<Name>", "x" * 65]
+
+        for name in invalid_names:
+            with self.subTest(name=name), self.assertRaises(ValueError):
+                voiceprints.validate_voiceprint_name(name)
+
+    def test_validate_voiceprint_name_accepts_unicode(self):
+        self.assertEqual(voiceprints.validate_voiceprint_name("雷"), "雷")
+
+    def test_save_and_load_voiceprint_round_trip(self):
+        with self._temporary_voiceprints_dir():
+            profile = VoiceprintProfile(
+                name="Ray",
+                model_id=voiceprints.EMBEDDING_MODEL_ID,
+                schema_version=voiceprints.VOICEPRINT_SCHEMA_VERSION,
+                embedding_dim=2,
+                embedding=np.array([3.0, 4.0], dtype=np.float32),
+                enrollments=[{"source": "ray.wav", "duration_sec": 12.4}],
+            )
+
+            voiceprints.save_voiceprint(profile)
+            loaded = voiceprints.load_voiceprint("Ray")
+
+        self.assertEqual(loaded.name, "Ray")
+        self.assertEqual(loaded.embedding_dim, 2)
+        self.assertEqual(loaded.enrollments, [{"source": "ray.wav", "duration_sec": 12.4}])
+        self.assertTrue(np.allclose(loaded.embedding, np.array([0.6, 0.8], dtype=np.float32)))
+
+    def test_save_voiceprint_l2_normalises_embedding(self):
+        with self._temporary_voiceprints_dir():
+            profile = VoiceprintProfile(
+                name="Ray",
+                model_id=voiceprints.EMBEDDING_MODEL_ID,
+                schema_version=voiceprints.VOICEPRINT_SCHEMA_VERSION,
+                embedding_dim=2,
+                embedding=np.array([10.0, 0.0], dtype=np.float32),
+                enrollments=[],
+            )
+
+            voiceprints.save_voiceprint(profile)
+            payload = json.loads(voiceprints.voiceprint_path("Ray").read_text(encoding="utf-8"))
+
+        self.assertEqual(payload["embedding"], [1.0, 0.0])
+
+    def test_save_voiceprint_writes_schema_version_and_model_id(self):
+        with self._temporary_voiceprints_dir():
+            profile = VoiceprintProfile(
+                name="Ray",
+                model_id=voiceprints.EMBEDDING_MODEL_ID,
+                schema_version=voiceprints.VOICEPRINT_SCHEMA_VERSION,
+                embedding_dim=2,
+                embedding=np.array([1.0, 0.0], dtype=np.float32),
+                enrollments=[],
+            )
+
+            voiceprints.save_voiceprint(profile)
+            payload = json.loads(voiceprints.voiceprint_path("Ray").read_text(encoding="utf-8"))
+
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertEqual(payload["model_id"], "speaker-detection/embedding")
+
+    def test_list_voiceprints_sorted_by_name(self):
+        with self._temporary_voiceprints_dir():
+            for name in ["Zoe", "Alice"]:
+                voiceprints.save_voiceprint(
+                    VoiceprintProfile(
+                        name=name,
+                        model_id=voiceprints.EMBEDDING_MODEL_ID,
+                        schema_version=voiceprints.VOICEPRINT_SCHEMA_VERSION,
+                        embedding_dim=2,
+                        embedding=np.array([1.0, 0.0], dtype=np.float32),
+                        enrollments=[],
+                    )
+                )
+
+            names = [profile.name for profile in voiceprints.list_voiceprints()]
+
+        self.assertEqual(names, ["Alice", "Zoe"])
+
+    def test_remove_voiceprint_missing_raises(self):
+        with self._temporary_voiceprints_dir(), self.assertRaises(FileNotFoundError):
+            voiceprints.remove_voiceprint("Ray")
+
+    def test_merge_centroid_running_mean(self):
+        merged = voiceprints.merge_centroid(
+            np.array([1.0, 0.0], dtype=np.float32),
+            np.array([0.0, 1.0], dtype=np.float32),
+            existing_count=2,
+        )
+
+        self.assertTrue(np.allclose(merged, np.array([2 / 3, 1 / 3], dtype=np.float32)))
+
+    def test_cosine_similarity_matrix_known_values(self):
+        centroids = np.array([[1.0, 0.0], [0.0, 1.0]], dtype=np.float32)
+        profiles = [
+            VoiceprintProfile(
+                "Ray", voiceprints.EMBEDDING_MODEL_ID, 1, 2, np.array([1.0, 0.0]), []
+            ),
+            VoiceprintProfile(
+                "Alice", voiceprints.EMBEDDING_MODEL_ID, 1, 2, np.array([0.0, 1.0]), []
+            ),
+        ]
+
+        scores = voiceprints.cosine_similarity_matrix(centroids, profiles)
+
+        self.assertTrue(np.allclose(scores, np.eye(2, dtype=np.float32)))
+
+    def test_assign_voiceprints_above_threshold_with_margin(self):
+        scores = np.array([[0.91, 0.3], [0.2, 0.88]], dtype=np.float32)
+
+        result = voiceprints.assign_voiceprints(
+            scores,
+            ["SPEAKER_00", "SPEAKER_01"],
+            ["Ray", "Alice"],
+            threshold=0.5,
+            margin=0.05,
+        )
+
+        self.assertEqual(result, {"SPEAKER_00": "Ray", "SPEAKER_01": "Alice"})
+
+    def test_assign_voiceprints_rejects_when_margin_violated(self):
+        scores = np.array([[0.91, 0.89]], dtype=np.float32)
+
+        result = voiceprints.assign_voiceprints(
+            scores,
+            ["SPEAKER_00"],
+            ["Ray", "Alice"],
+            threshold=0.5,
+            margin=0.05,
+        )
+
+        self.assertEqual(result, {})
+
+    def test_assign_voiceprints_resolves_mutual_exclusivity_via_bipartite(self):
+        scores = np.array([[0.9, 0.9], [0.9, 0.1]], dtype=np.float32)
+
+        result = voiceprints.assign_voiceprints(
+            scores,
+            ["SPEAKER_00", "SPEAKER_01"],
+            ["Ray", "Alice"],
+            threshold=0.5,
+            margin=0.0,
+        )
+
+        self.assertEqual(result, {"SPEAKER_00": "Alice", "SPEAKER_01": "Ray"})
+
+    def test_assign_voiceprints_more_speakers_than_voiceprints(self):
+        scores = np.array([[0.9], [0.1]], dtype=np.float32)
+
+        result = voiceprints.assign_voiceprints(
+            scores,
+            ["SPEAKER_00", "SPEAKER_01"],
+            ["Ray"],
+            threshold=0.5,
+            margin=0.0,
+        )
+
+        self.assertEqual(result, {"SPEAKER_00": "Ray"})
+
+    def test_assign_voiceprints_empty_voiceprints_returns_empty(self):
+        scores = np.empty((2, 0), dtype=np.float32)
+
+        result = voiceprints.assign_voiceprints(
+            scores,
+            ["SPEAKER_00", "SPEAKER_01"],
+            [],
+            threshold=0.5,
+            margin=0.05,
+        )
+
+        self.assertEqual(result, {})
+
+    def test_apply_speaker_map_renames_segment_and_word_speakers_only(self):
+        transcript = {
+            "segments": [
+                {
+                    "speaker": "SPEAKER_00",
+                    "text": "SPEAKER_00 said hello",
+                    "words": [
+                        {"speaker": "SPEAKER_00", "word": "hello"},
+                        {"speaker": "SPEAKER_01", "word": "there"},
+                    ],
+                }
+            ]
+        }
+
+        voiceprints.apply_speaker_map_to_transcript(transcript, {"SPEAKER_00": "Ray"})
+
+        segment = transcript["segments"][0]
+        self.assertEqual(segment["speaker"], "Ray")
+        self.assertEqual(segment["text"], "SPEAKER_00 said hello")
+        self.assertEqual(segment["words"][0]["speaker"], "Ray")
+        self.assertEqual(segment["words"][1]["speaker"], "SPEAKER_01")
+
+    def _temporary_voiceprints_dir(self):
+        return TemporaryVoiceprintsDir()
+
+
+class TemporaryVoiceprintsDir:
+    def __enter__(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.original = voiceprints.VOICEPRINTS_DIR
+        voiceprints.VOICEPRINTS_DIR = Path(self.temp_dir.name)
+        return voiceprints.VOICEPRINTS_DIR
+
+    def __exit__(self, exc_type, exc, tb):
+        voiceprints.VOICEPRINTS_DIR = self.original
+        self.temp_dir.cleanup()


### PR DESCRIPTION
## Summary

- Add local speaker voiceprint profiles and GUI management for enrolling and removing profiles.
- Capture diarization speaker embeddings during GUI transcription and relabel speakers when a confident voiceprint match exists.
- Keep transcription behavior unchanged when no voiceprints are enrolled, with focused storage, assignment, and GUI workflow tests.

## Validation

- python -m unittest tests.test_voiceprints tests.test_voiceprint_identification tests.test_gui_voiceprint_identification -v
