### PR TITLE
ci: add bandit security-scan job (Task A.2 from #158)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,25 @@ jobs:
 
       - name: Ruff format check
         run: uv run --no-sync ruff format --check .
+
+  security:
+    name: bandit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install bandit
+        # bandit scans source only, so the app runtime isn't needed.
+        run: uv sync --locked --only-group dev --no-install-project
+
+      - name: Bandit security scan
+        run: uv run --no-sync bandit -r aTrain -c pyproject.toml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,14 +15,15 @@ If you do not have uv installed yet, see the
 
 ## Running the CI checks locally
 
-The CI workflow runs `ruff` for linting and format checking. To
-reproduce the same checks locally before pushing:
+The CI workflow runs `ruff` (lint + format) and `bandit` (security
+scan). To reproduce the same checks locally before pushing:
 
 ```bash
-uv sync --group dev             # install dev tools (ruff)
-uv run ruff check .             # lint
-uv run ruff format --check .    # format check (no rewrites)
-uv run ruff format .            # apply formatter
+uv sync --group dev                        # install dev tools
+uv run ruff check .                        # lint
+uv run ruff format --check .               # format check (no rewrites)
+uv run ruff format .                       # apply formatter
+uv run bandit -r aTrain -c pyproject.toml  # security scan
 ```
 
 `uv sync --locked --group dev` is also used by CI to validate that

--- a/aTrain/utils/archive.py
+++ b/aTrain/utils/archive.py
@@ -1,6 +1,6 @@
 import os
 import shutil
-import subprocess
+import subprocess  # nosec B404 — used only with a static argv, never a shell
 import sys
 from importlib.resources import files
 
@@ -71,7 +71,7 @@ def open_file_directory(file_id) -> None:
     directory = os.path.join(TRANSCRIPT_DIR, file_id)
     if os.path.exists(directory):
         if sys.platform.startswith("linux"):
-            subprocess.run(["xdg-open", directory], check=False)
+            subprocess.run(["xdg-open", directory], check=False)  # nosec B603 B607 — fixed argv, no shell, no user input
         else:
             show_in_file_manager(directory)
 

--- a/aTrain/utils/models.py
+++ b/aTrain/utils/models.py
@@ -105,7 +105,7 @@ async def download_model(model: str):
 def check_internet() -> None:
     """A function to check whether the user is connected to the internet."""
     try:
-        urllib.request.urlopen("https://huggingface.co", timeout=10)
+        urllib.request.urlopen("https://huggingface.co", timeout=10)  # nosec B310 — hardcoded https URL, not user input
     except urllib.error.URLError:
         raise ConnectionError(
             "We cannot reach Hugging Face. Most likely you are not connected to the internet."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,4 +56,10 @@ torchvision = [{ index = "pytorch-cu128", marker = "sys_platform == 'linux'" }]
 [dependency-groups]
 dev = [
   "ruff>=0.15.0",
+  "bandit[toml]>=1.9.0",
 ]
+
+[tool.bandit]
+# Only the aTrain package is scanned (CI runs `bandit -r aTrain`); these
+# excludes keep ad-hoc local runs from descending into build/venv/model dirs.
+exclude_dirs = [".venv", "build", "dist", "aTrain.egg-info", "aTrain/required_models"]

--- a/uv.lock
+++ b/uv.lock
@@ -234,6 +234,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "bandit" },
     { name = "ruff" },
 ]
 
@@ -250,7 +251,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "ruff", specifier = ">=0.15.0" }]
+dev = [
+    { name = "bandit", extras = ["toml"], specifier = ">=1.9.0" },
+    { name = "ruff", specifier = ">=0.15.0" },
+]
 
 [[package]]
 name = "atrain-core"
@@ -302,6 +306,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/06/1364c445f8a8ab4870f0f5c4530b496257ae09de7fa01b6108525abea8b9/av-12.3.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a3703a35481fda5798a27bf6208c1ec3b61c18931625771fb3c9fd870539c7d7", size = 32217647, upload-time = "2024-07-21T04:01:07.549Z" },
     { url = "https://files.pythonhosted.org/packages/27/08/220d5a1ae7e7830d66d041c71e607c1f5df2e3598b12fb406b0d7c2defa7/av-12.3.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:32f3eef56b2df289db6105f9fe2ebc9a8134a8adbd62190daeb8e22c4ff47794", size = 34746451, upload-time = "2024-07-21T04:01:10.506Z" },
     { url = "https://files.pythonhosted.org/packages/96/67/9f1c444864d4f3e3773100b9ed20e670f80d5575b7a8fd53cca20de9d681/av-12.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:62d036ee8321d67190887012c3dbcd1ad83248603cc29ea75fbb75835b8d6e6e", size = 25977611, upload-time = "2024-07-21T04:01:13.709Z" },
+]
+
+[[package]]
+name = "bandit"
+version = "1.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "stevedore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c3/0cb80dfe0f3076e5da7e4c5ad8e57bac6ac357ff4a6406205501cade4965/bandit-1.9.4.tar.gz", hash = "sha256:b589e5de2afe70bd4d53fa0c1da6199f4085af666fde00e8a034f152a52cd628", size = 4242677, upload-time = "2026-02-25T06:44:15.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/a4/a26d5b25671d27e03afb5401a0be5899d94ff8fab6a698b1ac5be3ec29ef/bandit-1.9.4-py3-none-any.whl", hash = "sha256:f89ffa663767f5a0585ea075f01020207e966a9c0f2b9ef56a57c7963a3f6f8e", size = 134741, upload-time = "2026-02-25T06:44:13.694Z" },
 ]
 
 [[package]]
@@ -3382,6 +3401,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
+name = "stevedore"
+version = "5.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/88/35e4d27d9177d7df76d060e0a18f69c6c5794c96960c94042e20a12c8ba2/stevedore-5.8.0.tar.gz", hash = "sha256:b49867b32ca3016e94100e68dbf26e72aa7b8708d0a3f73c08aeb220370ac715", size = 514710, upload-time = "2026-05-18T09:15:27.731Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/ac/19f9941c74add59d17694930ec8105d5eddeee4ce56dd8632b765ca16d6c/stevedore-5.8.0-py3-none-any.whl", hash = "sha256:88eede9e66ca80e34085b9174e2327da2c61ac91f24f70e41c3ad76e4bb4872b", size = 54553, upload-time = "2026-05-18T09:15:25.82Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Follow-up to the ruff CI PR (#160). Adds `bandit` as its own dedicated
CI job, separate from the ruff job — one tool per job, per the review
on #160, so a failure attributes immediately to the right tool.

Contributes to #158 (Task A — CI lint/format/security).

## What this PR does

- Adds `bandit[toml]>=1.9.0` to `[dependency-groups] dev` and a minimal
  `[tool.bandit]` block (`exclude_dirs` for build/venv/model dirs).
- Adds a `bandit` CI job, installed the same lightweight way as ruff
  (`uv sync --locked --only-group dev --no-install-project` — bandit
  scans source, the app runtime isn't needed).
- Annotates the four baseline findings with scoped `# nosec` comments +
  rationale on the offending lines (not a global skip list, so any new
  occurrence elsewhere is still flagged):
  - `import subprocess` (B404) — static argv, never a shell
  - `subprocess.run(["xdg-open", …])` (B603, B607) — fixed argv, no
    shell, no user input
  - `urllib.request.urlopen("https://huggingface.co", …)` (B310) —
    hardcoded https URL, not user input
- Documents the local `bandit` command in `CONTRIBUTING.md`.

## Why bandit alongside ruff's S rules

ruff's `S` category (flake8-bandit) already covers overlapping checks,
but bandit is the named scanner BSI compliance reports cite, produces
its own report format, and versions independently — so a dedicated,
clearly-labelled `bandit` job is worth the small overlap.

## Maps to BSI IT-Grundschutz

- CON.8 §3.2.5 (Funktionstests und Sicherheitstests, automatisierte
  Codeanalyse) — bandit covers the named security-testing half.

## Note

The grandfathered S607/B607 finding (`xdg-open` partial path) could
alternatively be *fixed* via `shutil.which(...)`; deferred to a
follow-up with test coverage rather than changing behaviour here.

cc @gerardo-navarro