### PR TITLE
test: add first unit test batch (archive.py) + lightweight unit CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,9 +170,13 @@ jobs:
         run: uv run --no-sync pytest tests/core tests/ui -v
 
   unit:
-    name: unit
-    runs-on: ubuntu-latest
+    name: unit (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       - name: Checkout
@@ -190,6 +194,9 @@ jobs:
         # aTrain_core is installed with --no-deps (we need only
         # aTrain_core.globals, which imports just platformdirs), plus the few
         # light libraries archive.py imports, plus pytest. Stays in seconds.
+        # `shell: bash` so the `\` line-continuations work on windows-latest too
+        # (default Windows shell is pwsh, which uses backtick instead).
+        shell: bash
         run: |
           uv venv
           uv pip install --no-deps \
@@ -197,4 +204,6 @@ jobs:
           uv pip install platformdirs pyyaml show-in-file-manager pytest
 
       - name: Run unit tests
-        run: .venv/bin/python -m pytest tests/unit -v
+        # `uv run --no-sync` finds the venv we just built and invokes pytest
+        # cross-platform (no `.venv/bin` vs `.venv/Scripts` split).
+        run: uv run --no-sync pytest tests/unit -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,9 @@ jobs:
           uv pip install platformdirs pyyaml show-in-file-manager pytest
 
       - name: Run unit tests
-        # `uv run --no-sync` finds the venv we just built and invokes pytest
-        # cross-platform (no `.venv/bin` vs `.venv/Scripts` split).
-        run: uv run --no-sync pytest tests/unit -v
+        # `uv run --no-sync` finds the venv we just built and invokes python
+        # cross-platform (no `.venv/bin` vs `.venv/Scripts` split). `python -m
+        # pytest` (rather than bare `pytest`) is required so cwd is added to
+        # sys.path — the tests import `aTrain` from the repo root, which is
+        # not installed as a package in this job.
+        run: uv run --no-sync python -m pytest tests/unit -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,3 +168,33 @@ jobs:
         # just installed. `uv run` puts .venv/bin on PATH for the `aTrain`
         # subprocess; --no-sync keeps the just-installed pytest in place.
         run: uv run --no-sync pytest tests/core tests/ui -v
+
+  unit:
+    name: unit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install unit-test deps (no torch, no GTK)
+        # The unit tests cover only torch- and NiceGUI-free helpers
+        # (aTrain/utils/archive.py), so we skip the heavy app runtime entirely.
+        # aTrain_core is installed with --no-deps (we need only
+        # aTrain_core.globals, which imports just platformdirs), plus the few
+        # light libraries archive.py imports, plus pytest. Stays in seconds.
+        run: |
+          uv venv
+          uv pip install --no-deps \
+            "aTrain_core @ git+https://github.com/JuergenFleiss/aTrain_core.git@develop"
+          uv pip install platformdirs pyyaml show-in-file-manager pytest
+
+      - name: Run unit tests
+        run: .venv/bin/python -m pytest tests/unit -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ dev = [
 exclude_dirs = [".venv", "build", "dist", "aTrain.egg-info", "aTrain/required_models"]
 
 [tool.pytest.ini_options]
+testpaths = ["tests"]
 # NiceGUI's `user` fixture (UI E2E) is async; auto mode lets pytest-asyncio
 # handle async tests/fixtures without per-item markers.
 asyncio_mode = "auto"

--- a/tests/unit/test_archive.py
+++ b/tests/unit/test_archive.py
@@ -1,0 +1,164 @@
+"""Unit tests for aTrain/utils/archive.py — the transcription-archive file handler.
+
+Characterization tests: they pin the module's current behaviour as a
+regression net. Torch- and NiceGUI-free, so they run in the lightweight
+`unit` CI job (no app runtime).
+"""
+
+import pytest
+from aTrain.utils import archive
+
+
+@pytest.fixture
+def archive_root(tmp_path, monkeypatch):
+    """Point archive.TRANSCRIPT_DIR at an isolated temp dir.
+
+    archive.py rebinds TRANSCRIPT_DIR into its own namespace via
+    `from aTrain_core.globals import ...`, so we patch the name on
+    `archive` (what the functions actually read), not on aTrain_core.globals.
+    The directory is NOT created here — several functions create it on
+    demand, and that behaviour is part of what these tests pin.
+    """
+    root = tmp_path / "transcriptions"
+    monkeypatch.setattr(archive, "TRANSCRIPT_DIR", root)
+    return root
+
+
+# --- read_metadata_from_dir_name: pure string parsing, no IO ---------------
+
+_LONG = "2024-01-01 12-00-00recording.mp3"  # > 20 chars
+
+
+@pytest.mark.parametrize(
+    ("directory", "expected_timestamp", "expected_filename"),
+    [
+        pytest.param(_LONG, _LONG[:20], _LONG[20:], id="long"),
+        # At exactly 20 chars the timestamp is filled (len >= 20) but the
+        # filename is not (len > 20 is False) — asymmetric boundary in the
+        # current code, pinned here on purpose.
+        pytest.param("x" * 20, "x" * 20, "-", id="exactly-20"),
+        pytest.param("short", "-", "-", id="short"),
+    ],
+)
+def test_metadata_from_dir_name(directory, expected_timestamp, expected_filename):
+    meta = archive.read_metadata_from_dir_name(directory)
+    assert meta["file_id"] == directory
+    assert meta["timestamp"] == expected_timestamp
+    assert meta["filename"] == expected_filename
+
+
+# --- check_access ----------------------------------------------------------
+
+
+def test_check_access_existing_dir(tmp_path):
+    assert archive.check_access(str(tmp_path)) is True
+
+
+def test_check_access_missing_path(tmp_path):
+    assert archive.check_access(str(tmp_path / "nope")) is False
+
+
+def test_check_access_readable_file(tmp_path):
+    f = tmp_path / "f.txt"
+    f.write_text("hi")
+    assert archive.check_access(str(f)) is True
+
+
+# --- read_directories ------------------------------------------------------
+
+
+def test_read_directories_creates_dir_when_missing(archive_root):
+    # The dir does not exist yet; read_directories must create it and return [].
+    assert not archive_root.exists()
+    assert archive.read_directories() == []
+    assert archive_root.is_dir()
+
+
+def test_read_directories_sorted_reverse_dirs_only(archive_root):
+    archive_root.mkdir()
+    for name in ("a", "b", "c"):
+        (archive_root / name).mkdir()
+    (archive_root / "loose_file.txt").write_text("x")
+    assert archive.read_directories() == ["c", "b", "a"]
+
+
+# --- read_metadata_file ----------------------------------------------------
+
+
+def test_read_metadata_file_injects_file_id(tmp_path):
+    meta_path = tmp_path / "metadata.txt"
+    meta_path.write_text("model: tiny\nlanguage: en\n")
+    meta = archive.read_metadata_file(str(meta_path), "dir-123")
+    assert meta["model"] == "tiny"
+    assert meta["language"] == "en"
+    assert meta["file_id"] == "dir-123"
+
+
+# --- read_all_metadata -----------------------------------------------------
+
+
+def test_read_all_metadata_uses_file_when_present(archive_root):
+    d = archive_root / "rec1"
+    d.mkdir(parents=True)
+    (d / archive.METADATA_FILENAME).write_text("model: tiny\n")
+    [meta] = archive.read_all_metadata(["rec1"])
+    assert meta["model"] == "tiny"
+    assert meta["file_id"] == "rec1"
+
+
+def test_read_all_metadata_falls_back_to_dir_name(archive_root):
+    (archive_root / "rec2").mkdir(parents=True)  # no metadata file
+    [meta] = archive.read_all_metadata(["rec2"])
+    assert meta["file_id"] == "rec2"
+    assert meta["filename"] == "-"  # short dir name → dir-name fallback
+
+
+# --- read_archive: the public orchestrator the GUI calls -------------------
+
+
+def test_read_archive_merges_file_and_dirname_metadata(archive_root):
+    # "bbb" has a metadata file, "aaa" does not. read_archive lists dirs
+    # reverse-sorted (bbb before aaa) and merges both metadata sources.
+    bbb = archive_root / "bbb"
+    bbb.mkdir(parents=True)
+    (bbb / archive.METADATA_FILENAME).write_text("model: tiny\n")
+    (archive_root / "aaa").mkdir(parents=True)
+
+    result = archive.read_archive()
+
+    assert [m["file_id"] for m in result] == ["bbb", "aaa"]
+    assert result[0]["model"] == "tiny"  # from the metadata file
+    assert result[1]["filename"] == "-"  # dir-name fallback for "aaa"
+
+
+# --- delete_transcription --------------------------------------------------
+
+
+def test_delete_transcription_removes_dir(archive_root):
+    d = archive_root / "rec3"
+    d.mkdir(parents=True)
+    archive.delete_transcription("rec3")
+    assert not d.exists()
+    assert archive_root.exists()
+
+
+def test_delete_transcription_all_clears_and_recreates(archive_root):
+    (archive_root / "rec4").mkdir(parents=True)
+    archive.delete_transcription("all")
+    assert archive_root.exists()
+    assert list(archive_root.iterdir()) == []
+
+
+# --- load_faqs: bundled resource access ------------------------------------
+
+
+def test_load_faqs_returns_list_of_qa_entries():
+    # Smoke test for importlib.resources.files("aTrain.static") resolving the
+    # bundled faq.yaml — the kind of resource lookup a packaging change can
+    # silently break.
+    # Note: load_faqs is annotated `-> dict` but the YAML is a list, so it
+    # actually returns a list[dict]; pinned here as-is (the wrong annotation
+    # is a separate flag, not a red test).
+    faqs = archive.load_faqs()
+    assert isinstance(faqs, list)
+    assert all("question" in entry and "answer" in entry for entry in faqs)


### PR DESCRIPTION
Implements the `unit` layer of the layered test setup proposed in #171. Verified green in a fork preview.

## What this adds

**`tests/unit/test_archive.py`** — 15 characterization tests for [`aTrain/utils/archive.py`], covering:

| Area | Functions |
|---|---|
| Parsing | `read_metadata_from_dir_name` |
| Access / reads | `check_access`, `read_directories`, `read_metadata_file`, `read_all_metadata` (both branches) |
| Orchestration | `read_archive` (the entry point the GUI calls) |
| Deletion | `delete_transcription` (single + `"all"` sentinel) |
| Resources | `load_faqs` (`importlib.resources` smoke test) |

Filesystem functions use `tmp_path` plus a small `archive_root` fixture that monkeypatches `archive.TRANSCRIPT_DIR`.

> **Two suspected bugs are pinned as-is** (not encoded as red tests) and will be flagged separately:
> - Asymmetric 20-char boundary in `read_metadata_from_dir_name` — `timestamp` uses `>=20`, `filename` uses `>20`.
> - `load_faqs` is annotated `-> dict` but returns a list.

**Config / CI changes:**

| File | Change |
|---|---|
| `.github/workflows/ci.yml` | New lightweight `unit` job (`pytest tests/unit`). Selection is by directory — #172 uses `tests/core` / `tests/ui`, no pytest markers. |
| `.ruff.toml` | Ignore `S101` (assert) under `tests/**`. |
| `pyproject.toml` | `[tool.pytest.ini_options] testpaths = ["tests"]`. |

## Install footprint

The unit tests only touch torch- and NiceGUI-free helpers, so the job skips the heavy app runtime entirely. It installs only:

- **`aTrain_core` with `--no-deps`** — just `aTrain_core.globals` is needed → pulls in only `platformdirs`.
- **`archive.py`'s light imports** — `pyyaml`, `show-in-file-manager`.
- **`pytest`.**

**Result:** no torch, no GTK → runs in seconds (~15 s on the fork preview).

`pytest` is installed in the job rather than added to the `dev` group, so `uv.lock` is untouched and the locked jobs (ruff / bandit / pip-audit) stay green.

## Test plan

- [ ] `unit` job green on this PR
- [ ] existing `ruff` / `bandit` / `pip-audit` jobs stay green (`uv.lock` unchanged)
- [ ] `pytest tests/unit` passes locally (15 passed; the parametrized function expands to 3 collected items, so pytest reports 15)

## Maps to BSI IT-Grundschutz

- CON.8 §3.2.5 (Funktionstests und Sicherheitstests) — automated tests complementing the static analysis (ruff / bandit / pip-audit) already in place.

## Related

- Proposal / discussion: #171
- Sibling: #172 (E2E test suite — independent)

cc @gerardo-navarro