### PR TITLE
test: add render smokes for about / faq / archive / models pages

### DIFF
--- a/tests/ui/test_pages_render.py
+++ b/tests/ui/test_pages_render.py
@@ -1,0 +1,75 @@
+"""Render smoke tests for the non-transcribe pages.
+
+Drives the in-process NiceGUI `user` fixture against `/about`, `/faq`,
+`/archive`, and `/models`, asserting each page renders without crashing
+and shows an expected anchor string. Complements
+test_click_through.py::test_main_page_renders which covers `/`.
+
+These are smokes, not interaction tests: they only verify the page mounts
+and a stable label is visible. They catch the "page no longer renders" /
+"import-time error in a page module" class of breakage without exercising
+buttons or dialogs.
+"""
+
+from pathlib import Path
+
+import aTrain.pages.about as about_page
+import aTrain.pages.archive as archive_page
+import aTrain.pages.faq as faq_page
+import aTrain.pages.models as models_page
+import aTrain_core.globals as core_globals
+import pytest
+from aTrain.utils import archive as archive_utils
+from aTrain.utils import models as models_utils
+from nicegui.testing import User
+
+
+@pytest.fixture
+def isolated_user_dir(tmp_path, monkeypatch):
+    """Redirect the on-disk paths the pages touch into tmp_path.
+
+    aTrain_core.globals computes TRANSCRIPT_DIR / MODELS_DIR at import time
+    from ATRAIN_USER_DIR, so by the time a test runs they are already frozen
+    Path objects. We patch the attributes directly on every module that
+    rebound them via `from aTrain_core.globals import ...` — the names the
+    page code actually reads.
+    """
+    transcript_dir = tmp_path / "transcriptions"
+    models_dir = tmp_path / "models"
+    for module, attr, value in [
+        (core_globals, "TRANSCRIPT_DIR", transcript_dir),
+        (core_globals, "MODELS_DIR", models_dir),
+        (core_globals, "REQUIRED_MODELS_DIR", models_dir),
+        (archive_utils, "TRANSCRIPT_DIR", transcript_dir),
+        (models_utils, "MODELS_DIR", models_dir),
+        (models_utils, "REQUIRED_MODELS_DIR", models_dir),
+    ]:
+        monkeypatch.setattr(module, attr, value)
+    return tmp_path
+
+
+@pytest.mark.module_under_test(about_page)
+async def test_about_page_renders(user: User):
+    await user.open("/about")
+    await user.should_see("About aTrain", retries=100)
+
+
+@pytest.mark.module_under_test(faq_page)
+async def test_faq_page_renders(user: User):
+    await user.open("/faq")
+    await user.should_see("Frequently Asked Questions", retries=100)
+
+
+@pytest.mark.module_under_test(archive_page)
+async def test_archive_page_renders_empty(isolated_user_dir: Path, user: User):
+    # No transcriptions on disk → the page still renders header + actions.
+    await user.open("/archive")
+    await user.should_see("Archive", retries=100)
+    await user.should_see("Show All")
+    await user.should_see("Delete All")
+
+
+@pytest.mark.module_under_test(models_page)
+async def test_models_page_renders(isolated_user_dir: Path, user: User):
+    await user.open("/models")
+    await user.should_see("Model Manager", retries=100)


### PR DESCRIPTION
Follow-up to the unit-tests PR #176 and the E2E PR #172. Adds in-process render smokes for the four non-transcribe pages, primarily as a safety net for the upcoming aTrain_core monorepo merge (#145).

## What this adds

- `tests/ui/test_pages_render.py` — four NiceGUI `user`-fixture smokes:
  - `test_about_page_renders` (`/about` → "About aTrain")
  - `test_faq_page_renders` (`/faq` → "Frequently Asked Questions")
  - `test_archive_page_renders_empty` (`/archive` → "Archive" + "Show All" + "Delete All")
  - `test_models_page_renders` (`/models` → "Model Manager")

These verify each page mounts and a stable header is visible. They catch the common refactor-break case of "page no longer renders" / "import-time error in a page module" without exercising buttons or dialogs. Complements `test_click_through.py::test_main_page_renders` which covers `/`.

## Filesystem isolation

The archive and models pages call `read_archive()` / `read_model_metadata()` on render, which would otherwise create directories under the user's `~/Documents/aTrain`. An `isolated_user_dir` fixture redirects `TRANSCRIPT_DIR`, `MODELS_DIR` and `REQUIRED_MODELS_DIR` to `tmp_path` on every module that rebound them via `from aTrain_core.globals import …` (the names the page code actually reads — patching `aTrain_core.globals` alone is not enough because each importer holds its own binding, same pattern as `test_archive.py::archive_root`).

## CI

Lives in `tests/ui`, so it runs in the existing `e2e (app, full stack)` job alongside the click-through test.

## Test plan

- `e2e (app, full stack)` job green on this PR (includes `pytest tests/ui` — the 4 new smokes plus the existing 2)
- existing jobs (`ruff`, `bandit`, `pip-audit`, `unit`, `e2e (core pipeline)`) stay green (no `uv.lock` change)
- locally: `pytest tests/ui/test_pages_render.py` → 4 passed

## Maps to BSI IT-Grundschutz

- CON.8 §3.2.5 (Funktionstests und Sicherheitstests) — broader functional coverage of the UI surface so refactors that break a page's render path get caught immediately.

## Related

- Proposal / discussion: #171
- Predecessor: #176 (first unit test batch — archive.py)
- Sibling: #172 (E2E test suite)

cc @gerardo-navarro
