### PR TITLE
test: add interaction smokes for transcribe-page settings components

### DIFF
--- a/aTrain/components/settings/model.py
+++ b/aTrain/components/settings/model.py
@@ -11,6 +11,7 @@ def input_model():
         with ui.select(options=get_model_options()).classes("w-full") as input:
             input.classes("w-full")
             input.props("filled bg-color=gray-100 color=dark")
+            input.mark("select_model")
 
     input.bind_value(app.storage.general, "model")
     input.on_value_change(update_language_options)

--- a/aTrain/components/settings/speaker_detection.py
+++ b/aTrain/components/settings/speaker_detection.py
@@ -5,6 +5,6 @@ def input_speaker_detection():
     with ui.column().classes("gap-2"):
         ui.label("Speaker Detection").classes("font-bold text-dark text-md")
         ui.separator()
-        input = ui.switch("Speaker Detection")
+        input = ui.switch("Speaker Detection").mark("switch_speaker_detection")
         input.props("color=dark")
     input.bind_value(app.storage.general, "speaker_detection")

--- a/tests/ui/test_settings_components.py
+++ b/tests/ui/test_settings_components.py
@@ -1,0 +1,145 @@
+"""Interaction tests for the always-visible transcribe-page settings.
+
+Covers the four settings always visible on `/`: speaker-detection,
+speaker-count, language, model. Mounts the real transcribe page and
+drives each through the NiceGUI in-process `user` fixture, asserting
+their user-visible state transitions (storage binding, default-value
+selection, select-option changes, visibility binding).
+
+Out of scope here — `advanced_settings` (GPU, compute-type, cpu-threads,
+temperature, initial-prompt) sits behind a dialog and lazy-imports
+`torch.cuda`; it is a separate follow-up.
+
+The transcribe page is the natural place to exercise these components —
+each one is mounted there exactly as a user sees it (rather than in a
+synthetic test page), which keeps the test environment honest.
+"""
+
+import aTrain.pages.transcribe as transcribe_page
+import aTrain_core.transcribe  # noqa: F401  pre-import so the splash import is instant
+import pytest
+from aTrain.components.settings import model as model_component
+from nicegui import app, ui
+from nicegui.testing import User
+
+# All tests in this module render the real transcribe page (`/`).
+pytestmark = pytest.mark.module_under_test(transcribe_page)
+
+
+# app.storage.general is cleared between tests by NiceGUI's own
+# `nicegui_reset_globals` fixture (autouse via the `user` fixture chain),
+# which calls app.reset() → self.storage.clear() and binding.reset().
+# No explicit per-test storage cleanup needed.
+
+
+@pytest.fixture
+def known_models(monkeypatch):
+    """Make input_model see a predictable set of models (`tiny`, `base`)
+    regardless of what's downloaded on the host."""
+    monkeypatch.setattr(model_component, "read_transcription_models", lambda: ["tiny", "base"])
+
+
+def _find_ancestor_column(user: User, label_text: str) -> ui.column:
+    """Locate the `ui.column` whose subtree contains a label with the given text.
+
+    Walks the client's full element registry — `user.find(ui.column)` skips
+    elements with `visible=False`, which is exactly the case we need to assert
+    for the speaker-count visibility binding.
+    """
+    for element in user.client.elements.values():
+        if getattr(element, "text", None) == label_text and element.parent_slot:
+            parent = element.parent_slot.parent
+            while parent is not None:
+                if isinstance(parent, ui.column):
+                    return parent
+                parent = parent.parent_slot.parent if parent.parent_slot else None
+    raise AssertionError(f"no ui.column ancestor found for label {label_text!r}")
+
+
+# --- speaker_detection: switch toggles, value writes into storage ----------
+
+
+async def test_speaker_detection_toggle_writes_storage(user: User):
+    await user.open("/")
+    await user.should_see("Speaker Detection", retries=100)
+    # Select the speaker-detection switch by its mark — `find(ui.switch)`
+    # alone would also match the GPU switch inside advanced_settings if
+    # that dialog ever defaults open.
+    user.find(marker="switch_speaker_detection").click()
+    assert app.storage.general["speaker_detection"] is True
+    user.find(marker="switch_speaker_detection").click()
+    assert app.storage.general["speaker_detection"] is False
+
+
+# --- speaker_count: column visibility binds to speaker_detection -----------
+
+
+async def test_speaker_count_column_visibility_follows_detection(user: User):
+    # The column wrapping "Number of Speakers" binds its `.visible` attribute
+    # to app.storage.general["speaker_detection"]. should_see / should_not_see
+    # only check element existence (the DOM keeps hidden elements), so we
+    # assert the `.visible` attribute on the column directly.
+    await user.open("/")
+    await user.should_see("Speaker Detection", retries=100)
+    column = _find_ancestor_column(user, "Number of Speakers")
+    assert column.visible is False  # detection off / missing → hidden
+    user.find(marker="switch_speaker_detection").click()  # enable detection
+    assert column.visible is True
+    user.find(marker="switch_speaker_detection").click()  # disable again
+    assert column.visible is False
+
+
+# --- language: select falls back to first available language for a model ---
+
+
+async def test_language_select_picks_default_for_known_model(user: User, known_models):
+    # With `tiny` as the first available model, input_model writes
+    # model="tiny" into storage; input_language then seeds language to the
+    # first key in languages.json for that model, which is "auto-detect"
+    # for the multilingual tiny model.
+    await user.open("/")
+    await user.should_see("Select Language", retries=100)
+    assert app.storage.general["model"] == "tiny"
+    assert app.storage.general["language"] == "auto-detect"
+
+
+# --- language: opening the select and picking a different option ----------
+
+
+async def test_language_select_change_writes_storage(user: User, known_models):
+    await user.open("/")
+    await user.should_see("Select Language", retries=100)
+    # input_language tags its select with `.mark("select_language")`, which
+    # lets us drive it directly: first click opens the popup, second click
+    # on the option label picks it.
+    user.find(marker="select_language").click()
+    user.find("english").click()
+    assert app.storage.general["language"] == "en"
+
+
+# --- model: default seeded on first render --------------------------------
+
+
+async def test_model_default_seeded_on_first_render(user: User, known_models):
+    await user.open("/")
+    await user.should_see("Select Model", retries=100)
+    # `tiny` is the first entry → input_model picks it as the default.
+    assert app.storage.general["model"] == "tiny"
+
+
+# --- model: changing the model select also refreshes the language list ----
+
+
+async def test_model_select_change_writes_storage_and_refreshes_language(user: User, known_models):
+    await user.open("/")
+    await user.should_see("Select Model", retries=100)
+    assert app.storage.general["model"] == "tiny"
+    # Pick the model select by its mark and drive its value. `set_value`
+    # triggers the on_value_change handler which then calls
+    # update_language_options.
+    model_select = next(iter(user.find(marker="select_model").elements))
+    model_select.set_value("base")
+    assert app.storage.general["model"] == "base"
+    # `base` is also multilingual → update_language_options seeds the first
+    # key for the new model, which is "auto-detect".
+    assert app.storage.general["language"] == "auto-detect"


### PR DESCRIPTION
Follow-up to the unit-tests PR #176. Mounts the real transcribe page (`/`) and drives each of the always-visible settings components through the in-process `user` fixture, asserting the user-visible state transitions: storage binding, default-value selection, and select-change side effects.

## What this adds

- `tests/ui/test_settings_components.py` — six NiceGUI `user`-fixture tests:
  - `test_speaker_detection_toggle_writes_storage` — click the switch, assert `app.storage.general["speaker_detection"]` flips True/False
  - `test_speaker_count_column_visibility_follows_detection` — assert the speaker-count column's `.visible` attribute toggles with the speaker-detection switch (`should_see`/`should_not_see` can't observe DOM visibility, so we read the attribute directly)
  - `test_model_default_seeded_on_first_render` — with a monkeypatched `read_transcription_models` returning `["tiny", "base"]`, assert `input_model` seeds `"tiny"` into storage
  - `test_model_select_change_writes_storage_and_refreshes_language` — change the model select to `"base"`, assert storage update **and** that `update_language_options` re-seeded the language for the new model
  - `test_language_select_picks_default_for_known_model` — same model fixture, assert `input_language` seeds `"auto-detect"` (the first languages.json key for the multilingual `tiny` model)
  - `test_language_select_change_writes_storage` — open the language select popup, click `"english"`, assert `storage["language"] == "en"`

## Small source changes for robust widget selection

Two of the settings components get a NiceGUI `.mark(...)` so the tests select widgets by marker rather than positionally:

- `speaker_detection.py` — `.mark("switch_speaker_detection")` on the switch. Without this, `user.find(ui.switch)` would also collide with the GPU switch inside `advanced_settings` if that dialog ever defaults open.
- `model.py` — `.mark("select_model")` on the select. Mirrors the existing `.mark("select_language")` on the language select.

Both are single-line additions; no behaviour change for the user.

## Out of scope

- **advanced_settings** (GPU, compute-type, cpu-threads, temperature, initial-prompt) sits behind a dialog and lazy-imports `torch.cuda`; it is a separate follow-up.

## Storage / binding isolation

Storage and bindings are cleared between tests automatically by NiceGUI's `nicegui_reset_globals` fixture (autouse via the `user` fixture chain → calls `app.reset()` + `binding.reset()`), so no per-test cleanup is needed in this file.

## CI

Lives in `tests/ui`, so it runs in the existing `e2e (app, full stack)` job alongside the click-through test.

## Test plan

- `e2e (app, full stack)` job green on this PR (includes `pytest tests/ui` — the 6 new tests plus existing ones)
- existing jobs (`ruff`, `bandit`, `pip-audit`, `unit`, `e2e (core pipeline)`) stay green (no `uv.lock` change)
- locally: `pytest tests/ui/test_settings_components.py` → 6 passed

## Maps to BSI IT-Grundschutz

- CON.8 §3.2.5 (Funktionstests und Sicherheitstests) — broader functional coverage of the UI / state-binding surface so refactors that break the storage contract get caught immediately.

## Related

- Proposal / discussion: #171
- Predecessor: #176 (first unit test batch — archive.py)
- Sibling: #172 (E2E test suite)

cc @gerardo-navarro
