### PR TITLE
test: add interaction smokes for archive + models pages

### DIFF
--- a/tests/ui/test_archive_interactions.py
+++ b/tests/ui/test_archive_interactions.py
@@ -1,0 +1,135 @@
+"""Interaction tests for the /archive page.
+
+Drives the buttons on the archive page through the NiceGUI in-process
+`user` fixture and asserts the resulting filesystem state (since the
+click handlers call `delete_transcription` and `open_file_directory`
+directly). The `show` action invokes `subprocess.run(["xdg-open", ...])`
+which would actually try to open a file manager on CI, so the
+underlying utility is monkeypatched to a recorder.
+"""
+
+import aTrain.pages.archive as archive_page
+import aTrain_core.globals as core_globals
+import pytest
+from aTrain.utils import archive as archive_utils
+from nicegui.testing import User
+
+pytestmark = pytest.mark.module_under_test(archive_page)
+
+
+@pytest.fixture
+def archive_root(tmp_path, monkeypatch):
+    """Redirect TRANSCRIPT_DIR to a tmp dir on every module that rebound it,
+    so the page reads/writes inside the test sandbox."""
+    root = tmp_path / "transcriptions"
+    root.mkdir()
+    for module in (core_globals, archive_utils):
+        monkeypatch.setattr(module, "TRANSCRIPT_DIR", root)
+    return root
+
+
+def _seed(root, *names):
+    """Create transcription subdirectories under root. No metadata file →
+    read_metadata_from_dir_name fallback path."""
+    for name in names:
+        (root / name).mkdir()
+
+
+@pytest.fixture
+def show_recorder(monkeypatch):
+    """Replace open_file_directory with a recorder so the test doesn't
+    actually shell out to xdg-open / show-in-file-manager."""
+    calls = []
+    monkeypatch.setattr(archive_page, "show", lambda file_id: calls.append(file_id))
+    return calls
+
+
+# --- list rendering --------------------------------------------------------
+
+
+async def test_archive_empty_renders_headers(user: User, archive_root):
+    await user.open("/archive")
+    await user.should_see("Archive", retries=100)
+    await user.should_see("Show All")
+    await user.should_see("Delete All")
+    # No transcriptions seeded → only the column-headers row is rendered.
+    await user.should_not_see("delete")  # per-row delete button absent
+    await user.should_not_see("open")
+
+
+async def test_archive_lists_seeded_transcriptions(user: User, archive_root):
+    # read_metadata_from_dir_name puts directory[20:] into "filename"; the
+    # first 20 chars are the timestamp slot. Pick names long enough that the
+    # filename portion is recognisable for the assertion.
+    _seed(archive_root, "2024-01-01-10-00-00-recordingA", "2024-01-02-10-00-00-recordingB")
+    await user.open("/archive")
+    await user.should_see("Archive", retries=100)
+    await user.should_see("recordingA")
+    await user.should_see("recordingB")
+
+
+# --- per-row delete (no dialog) -------------------------------------------
+
+
+async def test_archive_row_delete_button_removes_directory(user: User, archive_root):
+    # One seeded row → the page shows exactly one "delete" button, so
+    # user.find("delete").click() unambiguously targets that row's handler.
+    # The handler calls delete_transcription(file_id) + ui.navigate.reload();
+    # reload is a no-op in the in-process user fixture, so we assert on the
+    # filesystem instead of re-rendering.
+    _seed(archive_root, "rec1")
+    await user.open("/archive")
+    await user.should_see("Archive", retries=100)
+    user.find("delete").click()
+    assert list(archive_root.iterdir()) == []
+
+
+# --- show buttons (mocked open_file_directory) ----------------------------
+
+
+async def test_archive_show_all_button_invokes_show_with_all(
+    user: User, archive_root, show_recorder
+):
+    await user.open("/archive")
+    await user.should_see("Show All", retries=100)
+    user.find("Show All").click()
+    assert show_recorder == ["all"]
+
+
+async def test_archive_row_open_button_invokes_show_with_file_id(
+    user: User, archive_root, show_recorder
+):
+    # One seeded row → exactly one per-row "open" button, so the find
+    # unambiguously targets that row's handler. Symmetric to the show-all
+    # test above — verifies the per-row click is wired to show(file_id).
+    _seed(archive_root, "rec1")
+    await user.open("/archive")
+    await user.should_see("Archive", retries=100)
+    user.find("open").click()
+    assert show_recorder == ["rec1"]
+
+
+# --- delete-all dialog ----------------------------------------------------
+
+
+async def test_archive_delete_all_dialog_confirm_clears_directory(user: User, archive_root):
+    _seed(archive_root, "rec1", "rec2", "rec3")
+    await user.open("/archive")
+    await user.should_see("Delete All", retries=100)
+    user.find("Delete All").click()  # opens dialog_delete
+    await user.should_see("Are you sure you want to delete all transcriptions?")
+    user.find("Confirm").click()
+    # delete("all") removed everything and recreated the empty root.
+    assert archive_root.exists()
+    assert list(archive_root.iterdir()) == []
+
+
+async def test_archive_delete_all_dialog_cancel_keeps_transcriptions(user: User, archive_root):
+    _seed(archive_root, "rec1", "rec2")
+    await user.open("/archive")
+    await user.should_see("Delete All", retries=100)
+    user.find("Delete All").click()
+    await user.should_see("Are you sure you want to delete all transcriptions?")
+    user.find("Cancel").click()
+    # Nothing was deleted.
+    assert {p.name for p in archive_root.iterdir()} == {"rec1", "rec2"}

--- a/tests/ui/test_models_interactions.py
+++ b/tests/ui/test_models_interactions.py
@@ -1,0 +1,75 @@
+"""Interaction tests for the /models page.
+
+Drives the Download / Delete buttons on the models page through the
+NiceGUI in-process `user` fixture, asserting the page calls the right
+backend function with the right argument. The page reads from
+`read_model_metadata` and clicks invoke `download_model` /
+`remove_model`; all three are monkeypatched so the test doesn't hit
+HuggingFace, doesn't spawn a CPU-bound worker for an actual download,
+and doesn't depend on which models are present on the host.
+"""
+
+import aTrain.pages.models as models_page
+import pytest
+from nicegui.testing import User
+
+pytestmark = pytest.mark.module_under_test(models_page)
+
+
+def _fake_metadata():
+    """A predictable mix: one downloaded model (large-v1) and one not
+    downloaded (tiny). Both are outside REQUIRED_MODELS so the page
+    actually renders them as rows."""
+    return [
+        {"model": "tiny", "size": "75 MB", "downloaded": False},
+        {"model": "large-v1", "size": "3 GB", "downloaded": True},
+    ]
+
+
+@pytest.fixture
+def mocked_models(monkeypatch):
+    """Pin the models the page sees, and record any download/remove calls."""
+    download_calls = []
+    remove_calls = []
+
+    def _record_download(model):
+        # The real download_model is async, but the on_click handler returns
+        # whatever the lambda returns and NiceGUI awaits coroutines for us
+        # on the live server. In the user fixture the await chain isn't
+        # synchronously driven, so we record via a synchronous stub.
+        download_calls.append(model)
+
+    def _record_remove(model):
+        remove_calls.append(model)
+
+    monkeypatch.setattr(models_page, "read_model_metadata", _fake_metadata)
+    monkeypatch.setattr(models_page, "download_model", _record_download)
+    monkeypatch.setattr(models_page, "remove_model", _record_remove)
+    return download_calls, remove_calls
+
+
+async def test_models_page_lists_non_required_models(user: User, mocked_models):
+    await user.open("/models")
+    await user.should_see("Model Manager", retries=100)
+    await user.should_see("tiny")
+    await user.should_see("large-v1")
+    await user.should_see("75 MB")
+    await user.should_see("3 GB")
+
+
+async def test_download_button_invokes_download_model(user: User, mocked_models):
+    download_calls, _ = mocked_models
+    await user.open("/models")
+    await user.should_see("Model Manager", retries=100)
+    # Exactly one row is not-downloaded → exactly one "Download" button.
+    user.find("Download").click()
+    assert download_calls == ["tiny"]
+
+
+async def test_delete_button_invokes_remove_model(user: User, mocked_models):
+    _, remove_calls = mocked_models
+    await user.open("/models")
+    await user.should_see("Model Manager", retries=100)
+    # Exactly one row is downloaded → exactly one "Delete" button.
+    user.find("Delete").click()
+    assert remove_calls == ["large-v1"]


### PR DESCRIPTION
Follow-up to the unit-tests PR #176. Drives the buttons on `/archive` and `/models` through the in-process `user` fixture, asserting the button-click → backend-call paths the user actually relies on.

## What this adds

### `tests/ui/test_archive_interactions.py` — 7 tests

- empty archive renders headers + "Show All" / "Delete All" buttons, with no per-row buttons present
- two seeded transcriptions render with the right filename column
- per-row "delete" → directory removed from disk (one seeded row so the find resolves unambiguously; `ui.navigate.reload()` is a no-op in the user fixture so we assert on the filesystem instead of re-rendering)
- "Show All" → `open_file_directory("all")` invoked (the page-level `show` symbol is monkeypatched so the test doesn't shell out to `xdg-open` / `show-in-file-manager`)
- per-row "open" → `open_file_directory(file_id)` invoked (mocked)
- "Delete All" → opens `dialog_delete` → click "Confirm" → all transcriptions removed, root recreated empty
- "Delete All" → opens `dialog_delete` → click "Cancel" → nothing removed

### `tests/ui/test_models_interactions.py` — 3 tests

- page lists the non-required models with their size and actions
- "Download" button → `download_model(name)` invoked (mocked, so no HuggingFace round-trip and no real download)
- "Delete" button → `remove_model(name)` invoked (mocked)

## Filesystem / data-source isolation

A `TRANSCRIPT_DIR`-redirect fixture sandboxes the archive page's filesystem writes into `tmp_path` on every module that rebound `TRANSCRIPT_DIR` via `from aTrain_core.globals import …` — the names the page code actually reads. Same pattern as `test_archive.py::archive_root` and `test_pages_render.py::isolated_user_dir`.

The models page is fully mocked at the data-source boundary (`read_model_metadata` + `download_model` + `remove_model`) so the test doesn't depend on which models are downloaded on the host and never triggers a real HuggingFace download.

## CI

Lives in `tests/ui`, so it runs in the existing `e2e (app, full stack)` job alongside the click-through, page-render and settings-components tests.

## Test plan

- `e2e (app, full stack)` job green on this PR (includes `pytest tests/ui` — the 10 new tests plus existing ones)
- existing jobs (`ruff`, `bandit`, `pip-audit`, `unit`, `e2e (core pipeline)`) stay green (no `uv.lock` change)
- locally: `pytest tests/ui/test_archive_interactions.py tests/ui/test_models_interactions.py` → 10 passed

## Maps to BSI IT-Grundschutz

- CON.8 §3.2.5 (Funktionstests und Sicherheitstests) — broader functional coverage of the button-click → backend-call paths the user relies on (delete / download / show), so silent breakage gets caught at PR time rather than at runtime.

## Related

- Proposal / discussion: #171
- Predecessor: #176 (first unit test batch — archive.py)
- Sibling: #172 (E2E test suite)

cc @gerardo-navarro
