### PR TITLE
fix(archive): correct load_faqs return type to list[dict]

### DIFF
--- a/aTrain/utils/archive.py
+++ b/aTrain/utils/archive.py
@@ -76,11 +76,11 @@ def open_file_directory(file_id) -> None:
             show_in_file_manager(directory)
 
 
-def load_faqs() -> dict:
+def load_faqs() -> list[dict]:
     """A function that reads the content of the faq file."""
     faq_path = str(files("aTrain.static").joinpath("faq.yaml"))
     with open(faq_path, encoding="utf-8") as faq_file:
-        faqs: dict = yaml.safe_load(faq_file)
+        faqs: list[dict] = yaml.safe_load(faq_file)
     return faqs
 
 

--- a/tests/unit/test_archive.py
+++ b/tests/unit/test_archive.py
@@ -156,9 +156,6 @@ def test_load_faqs_returns_list_of_qa_entries():
     # Smoke test for importlib.resources.files("aTrain.static") resolving the
     # bundled faq.yaml — the kind of resource lookup a packaging change can
     # silently break.
-    # Note: load_faqs is annotated `-> dict` but the YAML is a list, so it
-    # actually returns a list[dict]; pinned here as-is (the wrong annotation
-    # is a separate flag, not a red test).
     faqs = archive.load_faqs()
     assert isinstance(faqs, list)
     assert all("question" in entry and "answer" in entry for entry in faqs)


### PR DESCRIPTION
\`load_faqs\` was annotated \`-> dict\`, but \`faq.yaml\` is a top-level YAML list, so the function has always returned \`list[dict]\`. The unit test from #176 pinned the actual shape (\`isinstance(faqs, list)\` + per-entry key checks) and left a note about the wrong annotation; this PR corrects the annotation and drops the stale note.

Pure annotation change — no behaviour difference, all 15 existing \`tests/unit/test_archive.py\` cases still pass.

cc @gerardo-navarro