### PR TITLE
chore: add GitHub pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Summary
+
+<!-- Describe why this PR is needed and what it does. -->
+
+## References
+
+<!-- e.g. Closes #123, Refs #456 -->
+
+## Screenshots / Examples
+
+<!-- For UI changes, attach before/after screenshots or a short clip -->
+
+<!-- For API changes, include example requests and responses -->
+
+## Verification Steps
+
+<!-- How to validate this PR locally: steps, commands to run, and what to look for. -->


### PR DESCRIPTION
## Summary

It's a small, non-functional change: it adds a default GitHub pull request template so future PR descriptions follow a consistent structure (Summary, References, Screenshots / Examples, Verification Steps). The motivation is standardization, nothing in the application code is touched.

## Verification Steps

After merge, open a new PR and confirm the description is pre-filled with the template sections.
