### PR TITLE
feat: add Docker dev container for isolated, browser-based development

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -26,3 +26,7 @@ env/
 # Sample data and docs (not needed in the image)
 sample_data/
 docs/
+
+# Dev-container runtime output (models + transcriptions); bind-mounted at
+# runtime, must not enter the build context.
+data/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,28 @@
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+.eggs/
+dist/
+build/
+*.spec
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# macOS
+.DS_Store
+
+# IDE
+.vscode/
+.idea/
+.claude/
+
+# Git
+.git/
+
+# Sample data and docs (not needed in the image)
+sample_data/
+docs/

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,8 @@ test.py
 aTrain/required_models/*
 .DS_Store
 .cache
-.pytest_cache
+.devcontainer/
+docker-compose.override.yml
+.env
+.env.local
+.env.*.local

--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,12 @@ aTrain/required_models/*
 .DS_Store
 .cache
 .pytest_cache
+
+# Local dev container overrides (personal, not committed)
 .devcontainer/
 docker-compose.override.yml
+
+# Environment files (may contain secrets)
 .env
 .env.local
 .env.*.local

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ test.py
 aTrain/required_models/*
 .DS_Store
 .cache
+.pytest_cache
 .devcontainer/
 docker-compose.override.yml
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@ aTrain/required_models/*
 .devcontainer/
 docker-compose.override.yml
 
+# Dev-container runtime output: models + transcriptions bind-mounted from
+# the container to ./data (root-owned). Never committed.
+data/
+
 # Environment files (may contain secrets)
 .env
 .env.local

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,39 @@ uv run aTrain start     # run the app
 If you do not have uv installed yet, see the
 [uv installation guide](https://docs.astral.sh/uv/#installation).
 
+## Linux: native GUI build dependencies
+
+On Linux the runtime includes `pywebview[GTK]`, whose `pygobject`/`pycairo`
+dependencies build from source and require the cairo/glib native libraries plus
+`pkg-config`. Install them before the first `uv sync` (Debian/Ubuntu):
+
+```bash
+sudo apt-get install -y libcairo2-dev libgirepository1.0-dev pkg-config libglib2.0-dev
+```
+
+The recommended Linux workflow is the [Docker dev container](#docker-development-environment),
+which installs these for you and runs the app in the browser.
+
+## Docker development environment
+
+For a reproducible, isolated setup that needs nothing on the host but Docker,
+use the bundled dev container. It pins the toolchain and the locked dependency
+graph, bind-mounts the source for live editing, and persists downloaded models
+and transcription output across rebuilds.
+
+```bash
+docker compose up        # builds the image and starts aTrain
+```
+
+The app is then served at `http://localhost:8080`.
+
+The container runs aTrain in **browser mode** (`aTrain start --no-native`). It
+deliberately does **not** ship the native desktop-window backend: `pywebview`'s
+GTK backend has no use in a headless container, and excluding it keeps the image
+lean and portable. Development inside the container is therefore browser-based
+only; contributors who need to exercise the native window can do so on their
+host after installing the GUI build dependencies above.
+
 ## Running the CI checks locally
 
 The CI workflow runs `ruff` (lint + format), `bandit` (security scan),
@@ -34,6 +67,50 @@ uv run pip-audit /tmp/audit --locked
 `uv sync --locked --group dev` is also used by CI to validate that
 `uv.lock` is in sync with `pyproject.toml`. Running `uv lock` locally
 after any dependency change keeps the lockfile current.
+
+## Running the tests locally
+
+The test suite lives under `tests/` and is split into three suites with
+different runtime needs. `pytest` is intentionally **not** part of the
+`dev` dependency group, i.e. each suite installs only what it needs, the
+same way CI does. Pick the suite that matches your change.
+
+```bash
+# Unit tests — torch- and NiceGUI-free helpers (aTrain/utils/archive.py).
+# Fast, no app runtime. Runs on Linux and Windows in CI.
+uv venv
+uv pip install --no-deps \
+  "aTrain_core @ git+https://github.com/JuergenFleiss/aTrain_core.git@develop"
+uv pip install platformdirs pyyaml show-in-file-manager pytest
+uv run --no-sync python -m pytest tests/unit -v
+```
+
+```bash
+# Core E2E — transcription engine smoke test (tests/core), CPU torch only.
+uv venv
+uv pip install \
+  "aTrain_core @ git+https://github.com/JuergenFleiss/aTrain_core.git@develop" \
+  "torch==2.9.1+cpu" "torchaudio==2.9.1+cpu" pytest pytest-asyncio \
+  --extra-index-url https://download.pytorch.org/whl/cpu \
+  --index-strategy unsafe-best-match
+.venv/bin/python -m pytest tests/core -v
+```
+
+```bash
+# App E2E — UI boot + click-through against the full shipped stack
+# (tests/ui). Needs the locked app runtime. These tests run NiceGUI in
+# browser mode (`--no-native`) via the in-process `user` fixture, so the
+# native pywebview[GTK] backend is NOT required — a plain locked sync is enough.
+uv sync --locked
+uv pip install pytest pytest-asyncio
+uv run --no-sync pytest tests/ui -v
+```
+
+The authoritative setup for every suite is the CI workflow at
+[`.github/workflows/ci.yml`](.github/workflows/ci.yml); the commands above
+mirror it. `tool.pytest.ini_options` in `pyproject.toml` sets
+`testpaths = ["tests"]` and `asyncio_mode = "auto"`, so the async UI
+fixtures need no per-test markers.
 
 # Branching
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,50 +68,6 @@ uv run pip-audit /tmp/audit --locked
 `uv.lock` is in sync with `pyproject.toml`. Running `uv lock` locally
 after any dependency change keeps the lockfile current.
 
-## Running the tests locally
-
-The test suite lives under `tests/` and is split into three suites with
-different runtime needs. `pytest` is intentionally **not** part of the
-`dev` dependency group, i.e. each suite installs only what it needs, the
-same way CI does. Pick the suite that matches your change.
-
-```bash
-# Unit tests — torch- and NiceGUI-free helpers (aTrain/utils/archive.py).
-# Fast, no app runtime. Runs on Linux and Windows in CI.
-uv venv
-uv pip install --no-deps \
-  "aTrain_core @ git+https://github.com/JuergenFleiss/aTrain_core.git@develop"
-uv pip install platformdirs pyyaml show-in-file-manager pytest
-uv run --no-sync python -m pytest tests/unit -v
-```
-
-```bash
-# Core E2E — transcription engine smoke test (tests/core), CPU torch only.
-uv venv
-uv pip install \
-  "aTrain_core @ git+https://github.com/JuergenFleiss/aTrain_core.git@develop" \
-  "torch==2.9.1+cpu" "torchaudio==2.9.1+cpu" pytest pytest-asyncio \
-  --extra-index-url https://download.pytorch.org/whl/cpu \
-  --index-strategy unsafe-best-match
-.venv/bin/python -m pytest tests/core -v
-```
-
-```bash
-# App E2E — UI boot + click-through against the full shipped stack
-# (tests/ui). Needs the locked app runtime. These tests run NiceGUI in
-# browser mode (`--no-native`) via the in-process `user` fixture, so the
-# native pywebview[GTK] backend is NOT required — a plain locked sync is enough.
-uv sync --locked
-uv pip install pytest pytest-asyncio
-uv run --no-sync pytest tests/ui -v
-```
-
-The authoritative setup for every suite is the CI workflow at
-[`.github/workflows/ci.yml`](.github/workflows/ci.yml); the commands above
-mirror it. `tool.pytest.ini_options` in `pyproject.toml` sets
-`testpaths = ["tests"]` and `asyncio_mode = "auto"`, so the async UI
-fixtures need no per-test markers.
-
 # Branching
 
 As the project grows and community contributions become more frequent (thanks all!) we opted to adopt a branching model with the intention to make it easier and clearer for contributors to make pull requests.

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,13 +1,11 @@
 FROM python:3.11-slim-bookworm
 
-# git: install aTrain_core from a GitHub ref
-# openssh-client: enables git over SSH from inside the dev container
+# git: install aTrain_core from its GitHub ref (over HTTPS)
 # gcc/g++: compile native extensions from aTrain_core deps
 # curl/ca-certificates: required to run the official uv installer below
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         git \
-        openssh-client \
         gcc \
         g++ \
         curl \
@@ -19,14 +17,6 @@ RUN apt-get update && \
 # on the system PATH so subsequent layers can call `uv` directly.
 ENV UV_INSTALL_DIR=/usr/local/bin
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
-
-# Pre-trust GitHub's host key so SSH-based `git pull`/`git fetch` works
-# non-interactively when the host SSH agent is forwarded in (the personal
-# docker-compose.override.yml mounts /run/host-services/ssh-auth.sock and sets
-# SSH_AUTH_SOCK). Without this, the first connection blocks on an interactive
-# "are you sure you want to continue connecting?" prompt.
-RUN mkdir -p /root/.ssh && chmod 700 /root/.ssh \
-    && ssh-keyscan github.com >> /root/.ssh/known_hosts 2>/dev/null
 
 WORKDIR /workspace
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,106 @@
+FROM python:3.11-slim-bookworm
+
+# git: install aTrain_core from a GitHub ref
+# openssh-client: enables git over SSH from inside the dev container
+# gcc/g++: compile native extensions from aTrain_core deps
+# curl/ca-certificates: required to run the official uv installer below
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        git \
+        openssh-client \
+        gcc \
+        g++ \
+        curl \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# uv: matches the workflow documented in CONTRIBUTING.md (uv sync / uv run).
+# Use the official standalone installer; UV_INSTALL_DIR places the binaries
+# on the system PATH so subsequent layers can call `uv` directly.
+ENV UV_INSTALL_DIR=/usr/local/bin
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Pre-trust GitHub's host key so SSH-based `git pull`/`git fetch` works
+# non-interactively when the host SSH agent is forwarded in (the personal
+# docker-compose.override.yml mounts /run/host-services/ssh-auth.sock and sets
+# SSH_AUTH_SOCK). Without this, the first connection blocks on an interactive
+# "are you sure you want to continue connecting?" prompt.
+RUN mkdir -p /root/.ssh && chmod 700 /root/.ssh \
+    && ssh-keyscan github.com >> /root/.ssh/known_hosts 2>/dev/null
+
+WORKDIR /workspace
+
+# Copy only dependency metadata first to leverage Docker layer caching.
+# The actual source is bind-mounted at runtime, but uv needs pyproject.toml
+# and uv.lock here to resolve and install dependencies, plus version.py
+# because the project version is read dynamically from it.
+COPY pyproject.toml uv.lock ./
+COPY aTrain/version.py aTrain/version.py
+
+# uv settings tuned for container builds:
+#   UV_LINK_MODE=copy        — bind-mounted /workspace is on a different
+#                              filesystem than /workspace/.venv, so hardlinks
+#                              would fail; copy is the safe default.
+#   UV_COMPILE_BYTECODE=1    — pre-compile .pyc on install for faster startup.
+#   UV_PYTHON_DOWNLOADS=never — use the system Python from this image, do not
+#                              let uv fetch its own interpreter.
+#   UV_HTTP_TIMEOUT=300      — the Linux lock pins torch==2.9.1+cu128, which
+#                              pulls the large nvidia-*-cu12 CUDA wheels (cublas
+#                              ~570 MiB, cusparselt ~270 MiB) from
+#                              download.pytorch.org. The default per-request
+#                              timeout aborts these mid-download on slower
+#                              links; 300s lets them complete.
+ENV UV_LINK_MODE=copy \
+    UV_COMPILE_BYTECODE=1 \
+    UV_PYTHON_DOWNLOADS=never \
+    UV_HTTP_TIMEOUT=300
+
+# Sync the locked dependency set. This image is built for linux/amd64 (pinned
+# in docker-compose.yml), so the x86_64 wheels in uv.lock — CUDA torch,
+# torchcodec, pyannote.audio, and aTrain_core@develop — all resolve directly.
+# This matches CONTRIBUTING.md's documented `uv sync` and what CI installs.
+#
+# The only deviation is the excluded packages below, all build/UX concerns
+# rather than platform concerns. The container runs aTrain with --no-native
+# (browser mode), so neither pywebview GUI backend is ever loaded:
+#   - pyqt5/pyqt6 chain + qtpy: need the Qt SDK to build from source.
+#   - pygobject/pygobject-stubs: pywebview's GTK backend. pygobject pulls in
+#     pycairo, which builds from an sdist and needs the cairo/glib native
+#     libraries plus pkg-config — none of which the GTK backend needs here.
+#   - dask: only used by full transcription, not by UI dev.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-install-project \
+        --no-install-package pyqt5 \
+        --no-install-package pyqtwebengine \
+        --no-install-package pyqt5-qt5 \
+        --no-install-package pyqt5-sip \
+        --no-install-package pyqtwebengine-qt5 \
+        --no-install-package pyqt6 \
+        --no-install-package pyqt6-qt6 \
+        --no-install-package pyqt6-sip \
+        --no-install-package pyqt6-webengine \
+        --no-install-package pyqt6-webengine-qt6 \
+        --no-install-package qtpy \
+        --no-install-package pygobject \
+        --no-install-package pygobject-stubs \
+        --no-install-package pycairo \
+        --no-install-package dask
+
+# Install the project itself. The source is bind-mounted at runtime, so this
+# layer only provides the console-script entry point and metadata.
+COPY . .
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --no-deps .
+
+# Put the uv-managed venv on PATH so the `aTrain` console script resolves
+# without an explicit `uv run`.
+ENV PATH="/workspace/.venv/bin:$PATH" \
+    VIRTUAL_ENV=/workspace/.venv
+
+# NiceGUI runs on 8080 by default
+EXPOSE 8080
+
+# Run in browser mode (no pywebview native window), with hot-reload.
+# The source directory is bind-mounted by docker-compose, so edits on the
+# host are reflected immediately inside the container.
+CMD ["aTrain", "start", "--no-native"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -92,5 +92,6 @@ EXPOSE 8080
 
 # Run in browser mode (no pywebview native window), with hot-reload.
 # The source directory is bind-mounted by docker-compose, so edits on the
-# host are reflected immediately inside the container.
-CMD ["aTrain", "start", "--no-native"]
+# host are reflected immediately inside the container; --reload restarts the
+# NiceGUI server on file change so contributors don't need a manual restart.
+CMD ["aTrain", "start", "--no-native", "--reload"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+services:
+  atrain:
+    # Force x86_64: the locked dependency graph (torch+cu128, torchcodec,
+    # pyannote.audio) ships x86_64-only wheels. On an ARM host (e.g. Apple
+    # Silicon / OrbStack) Docker runs this under emulation so a plain
+    # `uv sync` resolves exactly as it does in CI. Without this pin the build
+    # defaults to the host arch (aarch64), where torchcodec has no wheel and
+    # the develop-branch app fails to import pyannote.audio at startup.
+    platform: linux/amd64
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    ports:
+      - "8080:8080"
+    volumes:
+      # Bind mount: live source code editing from host
+      - .:/workspace
+      # Named volume: persists downloaded models and transcription output
+      # Maps to ATRAIN_DIR which aTrain_core resolves to ~/.local/share/aTrain
+      - atrain_data:/root/.local/share/aTrain
+    environment:
+      # Prevents Python from buffering stdout/stderr (cleaner container logs)
+      - PYTHONUNBUFFERED=1
+      # Prepend bind-mounted source so live edits take effect without reinstalling
+      - PYTHONPATH=/workspace
+      # Wakepy tries to prevent system sleep — not applicable in a headless container.
+      # This env var tells wakepy to silently succeed without touching the system.
+      - WAKEPY_FAKE_SUCCESS=1
+    restart: unless-stopped
+
+volumes:
+  atrain_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,14 @@ services:
     volumes:
       # Bind mount: live source code editing from host
       - .:/workspace
+      # Named volume: shadows the bind mount above so the image-built venv
+      # at the uv-default /workspace/.venv is not masked by the host directory
+      # (a fresh worktree has no .venv). Without this, PATH=/workspace/.venv/bin
+      # points at an empty dir and `aTrain` is "executable file not found".
+      # Seeded from the image on first start; recreate with `down -v` (or
+      # `docker volume rm atrain_venv`) after a dependency change so the
+      # rebuilt venv is picked up.
+      - atrain_venv:/workspace/.venv
       # Named volume: persists downloaded models and transcription output
       # Maps to ATRAIN_DIR which aTrain_core resolves to ~/.local/share/aTrain
       - atrain_data:/root/.local/share/aTrain
@@ -26,6 +34,17 @@ services:
       # Wakepy tries to prevent system sleep — not applicable in a headless container.
       # This env var tells wakepy to silently succeed without touching the system.
       - WAKEPY_FAKE_SUCCESS=1
+      # Align aTrain_core's data dir with the atrain_data volume mount below.
+      # aTrain_core checks ATRAIN_USER_DIR first; without it, ATRAIN_DIR falls
+      # back to platformdirs.user_documents_path() → /root/Documents/aTrain,
+      # which is outside the volume, so models and transcription output would
+      # land in the container layer and be lost on `docker compose down`.
+      - ATRAIN_USER_DIR=/root/.local/share/aTrain
+      # pyannote.audio 4.x requires an explicit telemetry opt-in/out and raises
+      # ValueError on model load if unset. aTrain_core only sets this default
+      # inside its Flatpak branch, so non-Flatpak runtimes (Docker) must set it.
+      - PYANNOTE_METRICS_ENABLED=false
 
 volumes:
+  atrain_venv:
   atrain_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,9 +23,14 @@ services:
       # `docker volume rm atrain_venv`) after a dependency change so the
       # rebuilt venv is picked up.
       - atrain_venv:/workspace/.venv
-      # Named volume: persists downloaded models and transcription output
-      # Maps to ATRAIN_DIR which aTrain_core resolves to ~/.local/share/aTrain
-      - atrain_data:/root/.local/share/aTrain
+      # Host bind mount: persists downloaded models and transcription output,
+      # and lets contributors open results (data/transcriptions/.../*.txt)
+      # directly in their editor instead of docker cp / exec out of a volume.
+      # Maps to ATRAIN_DIR (ATRAIN_USER_DIR below). The container writes as
+      # root, so files under data/ are root-owned; clean up with
+      # `docker compose exec atrain rm ...` or sudo. data/ is git- and
+      # docker-ignored.
+      - ./data:/root/.local/share/aTrain
     environment:
       # Prevents Python from buffering stdout/stderr (cleaner container logs)
       - PYTHONUNBUFFERED=1
@@ -34,10 +39,10 @@ services:
       # Wakepy tries to prevent system sleep — not applicable in a headless container.
       # This env var tells wakepy to silently succeed without touching the system.
       - WAKEPY_FAKE_SUCCESS=1
-      # Align aTrain_core's data dir with the atrain_data volume mount below.
+      # Align aTrain_core's data dir with the ./data bind mount above.
       # aTrain_core checks ATRAIN_USER_DIR first; without it, ATRAIN_DIR falls
       # back to platformdirs.user_documents_path() → /root/Documents/aTrain,
-      # which is outside the volume, so models and transcription output would
+      # which is outside the mount, so models and transcription output would
       # land in the container layer and be lost on `docker compose down`.
       - ATRAIN_USER_DIR=/root/.local/share/aTrain
       # pyannote.audio 4.x requires an explicit telemetry opt-in/out and raises
@@ -47,4 +52,3 @@ services:
 
 volumes:
   atrain_venv:
-  atrain_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,6 @@ services:
       # Wakepy tries to prevent system sleep — not applicable in a headless container.
       # This env var tells wakepy to silently succeed without touching the system.
       - WAKEPY_FAKE_SUCCESS=1
-    restart: unless-stopped
 
 volumes:
   atrain_data:


### PR DESCRIPTION
## Summary

Adds a reproducible, isolated **Docker development environment** so contributors can go from clone to a running aTrain with a single command, without installing Python, uv, the ML stack, or platform-specific native libraries on their host.

This implements the proposal in #153.

```bash
docker compose up   # builds the image, starts aTrain at http://localhost:8080
```

## What this adds

- **`Dockerfile.dev`** — pins Python + uv and installs the locked dependency graph (`uv.lock`). Built for `linux/amd64` so the x86_64-only locked wheels (CUDA torch, torchcodec, pyannote.audio) resolve directly, including under emulation on Apple Silicon.
- **`docker-compose.yml`** — bind-mounts the source for live editing, persists downloaded models and transcription output in a named volume, and exposes port 8080.
- **`.dockerignore`** — keeps the build context lean (venv, caches, docs, sample data).
- **`.gitignore`** — ignores the personal dev-container override layer and `.env*` files, so contributors can keep local tooling/credentials out of commits.
- **`CONTRIBUTING.md`** — documents the Docker workflow and the Linux native GUI build dependencies.

## Browser-based (non-native) development only

The native desktop window relies on `pywebview`, whose Linux backend (`pywebview[GTK]`) builds `pygobject`/`pycairo` from source and needs the cairo/glib native libraries plus `pkg-config`. A `pywebview` native window also has no display inside a headless container.

The image therefore **excludes the GTK backend** and runs aTrain in **browser mode** (`aTrain start --no-native`), served at `http://localhost:8080`. This keeps the image lean and portable. Contributors who need to exercise the native window can still do so on their host after installing the GUI build dependencies documented in `CONTRIBUTING.md`.

No changes to `pyproject.toml` or `uv.lock` — the shared dependency graph is untouched; the exclusion happens at install time in the image only.

## Test plan

- [ ] `docker compose up` builds the image and starts the app.
- [ ] aTrain is reachable at `http://localhost:8080`.
- [ ] Editing a source file on the host is reflected inside the container.
- [ ] `uv run aTrain init` downloads models; they persist across a container rebuild.
- [ ] Transcription output persists across a container rebuild.

Closes #153
