### PR TITLE
test: add interaction smokes for advanced_settings dialog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ aTrain/required_models/*
 .DS_Store
 .cache
 .pytest_cache
+.vscode

--- a/aTrain/components/settings/advanced.py
+++ b/aTrain/components/settings/advanced.py
@@ -33,6 +33,7 @@ def input_gpu():
         else:
             switch = ui.switch("GPU", value=False).props("color=dark disable")
             state["GPU"] = False
+        switch.mark("switch_gpu")
     switch.bind_value(state, "GPU")
     switch.on_value_change(set_compute_options)
 
@@ -71,8 +72,8 @@ def input_cpu_threads():
                 value=state.get("cpu_threads", DEFAULT_CPU_THREADS),
             )
             number.props("filled bg-color=gray-100 color=dark").classes("flex-grow")
-            number.bind_value(state, "cpu_threads")
-            reset_btn = ui.button(icon="refresh", color="gray-300")
+            number.bind_value(state, "cpu_threads").mark("number_cpu_threads")
+            reset_btn = ui.button(icon="refresh", color="gray-300").mark("button_reset_cpu_threads")
             reset_btn.props("flat dense round size=sm").tooltip("Reset to default")
             reset_btn.on_click(lambda: number.set_value(DEFAULT_CPU_THREADS))
 
@@ -85,9 +86,11 @@ def input_temperature():
         with ui.row().classes("w-full gap-2 items-center"):
             number = ui.number(min=0.0, max=1.0, step=0.1, precision=1, placeholder="auto")
             number.props("filled bg-color=gray-100 color=dark").classes("flex-grow")
-            number.bind_value(app.storage.general, "temperature_override")  # <- New state name
+            number.bind_value(app.storage.general, "temperature_override").mark(
+                "number_temperature"
+            )  # <- New state name
 
-            reset_btn = ui.button(icon="refresh", color="gray-300")
+            reset_btn = ui.button(icon="refresh", color="gray-300").mark("button_reset_temperature")
             reset_btn.props("flat dense round size=sm").tooltip("Reset to default (auto)")
             reset_btn.on_click(lambda: number.set_value(None))
 
@@ -99,7 +102,7 @@ def input_initial_prompt():
     with ui.column().classes("w-full gap-2"):
         ui.label("Initial Prompt").classes("font-bold text-dark")
         ui.separator()
-        textarea = ui.textarea(placeholder="Type here...")
+        textarea = ui.textarea(placeholder="Type here...").mark("textarea_initial_prompt")
         textarea.props("color=dark autogrow clearable").classes("w-full")
     textarea.bind_value(app.storage.general, "initial_prompt")
 

--- a/aTrain/pages/transcribe.py
+++ b/aTrain/pages/transcribe.py
@@ -29,7 +29,9 @@ async def page(client: Client):
             input_speaker_count()
         ui.separator().classes("mt-4")
         with ui.row().classes("w-full justify-between items-center"):
-            settings_btn = ui.button("Advanced Settings", color="gray-100")
+            settings_btn = ui.button("Advanced Settings", color="gray-100").mark(
+                "open_advanced_settings"
+            )
             settings_btn.props("size=0.8rem unelevated no-caps icon=settings")
             if FLATPAK:
 

--- a/tests/ui/test_advanced_settings.py
+++ b/tests/ui/test_advanced_settings.py
@@ -1,0 +1,146 @@
+"""Interaction tests for the advanced settings dialog.
+
+Covers the five settings inside `advanced_settings`: GPU, compute-type,
+cpu-threads, temperature, initial-prompt. Sister to
+`tests/ui/test_settings_components.py` (the always-visible transcribe-page
+settings); the GPU switch is the one input here that depends on host
+hardware (lazy `from torch import cuda`), so we mock `cuda.is_available`
+for deterministic behaviour across CPU-only and GPU runners.
+
+The dialog is mounted on the transcribe page (closed by default) plus a
+fresh one is created on each settings-button click. Tests that only need
+to read initial render state (CUDA-handling, default seeding) check
+`app.storage.general` directly; tests that drive inputs open the dialog
+first via the marked settings button so the interactive instance is in
+view.
+"""
+
+import aTrain.pages.transcribe as transcribe_page
+import aTrain_core.transcribe  # noqa: F401  pre-import so the splash import is instant
+import pytest
+from aTrain_core.cli import DEFAULT_CPU_THREADS
+from aTrain_core.settings import ComputeType
+from nicegui import app
+from nicegui.testing import User
+
+pytestmark = pytest.mark.module_under_test(transcribe_page)
+
+
+@pytest.fixture
+def no_cuda(monkeypatch):
+    """Force input_gpu to render as if CUDA is unavailable."""
+    monkeypatch.setattr("torch.cuda.is_available", lambda: False)
+
+
+@pytest.fixture
+def cuda_available(monkeypatch):
+    """Force input_gpu to render as if CUDA is available."""
+    monkeypatch.setattr("torch.cuda.is_available", lambda: True)
+
+
+async def _open_dialog(user: User):
+    """Render the page and click the settings button so the interactive
+    dialog instance is in view. The page also embeds a second closed
+    `advanced_settings(open=False)` dialog, so marker-based find can match
+    two elements; tests that interact pick the *last* one (the freshly
+    opened instance)."""
+    await user.open("/")
+    await user.should_see("Advanced Settings", retries=100)
+    user.find(marker="open_advanced_settings").click()
+
+
+def _last(user: User, marker: str):
+    """Return the most recently rendered element for a marker — the one
+    inside the just-opened dialog rather than the embedded closed one."""
+    return list(user.find(marker=marker).elements)[-1]
+
+
+# --- input_gpu: CUDA gating + storage seeding -----------------------------
+
+
+async def test_input_gpu_storage_seeded_false_when_no_cuda(user: User, no_cuda):
+    # input_gpu writes storage["GPU"] = False as a side effect when CUDA
+    # is unavailable, before the dialog is even opened.
+    await user.open("/")
+    await user.should_see("Advanced Settings", retries=100)
+    assert app.storage.general["GPU"] is False
+
+
+async def test_input_gpu_switch_defaults_to_true_with_cuda(user: User, cuda_available):
+    await _open_dialog(user)
+    await user.should_see("GPU acceleration", retries=100)
+    switch = _last(user, "switch_gpu")
+    assert switch.value is True
+
+
+async def test_input_gpu_toggle_writes_storage(user: User, cuda_available):
+    await _open_dialog(user)
+    await user.should_see("GPU acceleration", retries=100)
+    _last(user, "switch_gpu").set_value(False)
+    assert app.storage.general["GPU"] is False
+    _last(user, "switch_gpu").set_value(True)
+    assert app.storage.general["GPU"] is True
+
+
+# --- input_compute_type: default + GPU-off restriction -------------------
+
+
+async def test_input_compute_type_defaults_to_int8(user: User, cuda_available):
+    # The select is seeded from storage["compute_type"] or ComputeType.INT8.
+    # On first render storage is empty → INT8.
+    await _open_dialog(user)
+    await user.should_see("Compute Type", retries=100)
+    assert app.storage.general["compute_type"] == ComputeType.INT8.value
+
+
+async def test_input_compute_type_options_restricted_when_gpu_off(user: User, no_cuda):
+    # input_gpu sets storage["GPU"]=False → set_compute_options() collapses
+    # the select options to [INT8] only.
+    await _open_dialog(user)
+    await user.should_see("Compute Type", retries=100)
+    select = _last(user, "select_compute")
+    assert list(select.options) == [ComputeType.INT8.value]
+
+
+# --- input_cpu_threads: default + reset button ---------------------------
+
+
+async def test_input_cpu_threads_default_and_reset(user: User, cuda_available):
+    await _open_dialog(user)
+    await user.should_see("CPU Threads", retries=100)
+    number = _last(user, "number_cpu_threads")
+    assert number.value == DEFAULT_CPU_THREADS
+    number.set_value(8)
+    assert number.value == 8
+    # Both the embedded closed dialog and the opened one register a reset
+    # button under the same marker; `find(...).click()` hits the first, but
+    # the lambda set_value flows back through bind_value to storage and
+    # then back to *all* bound numbers — so the assert holds either way.
+    user.find(marker="button_reset_cpu_threads").click()
+    assert number.value == DEFAULT_CPU_THREADS
+
+
+# --- input_temperature: default + reset button --------------------------
+
+
+async def test_input_temperature_default_none_and_reset(user: User, cuda_available):
+    await _open_dialog(user)
+    await user.should_see("Temperature", retries=100)
+    number = _last(user, "number_temperature")
+    assert number.value is None  # placeholder "auto"
+    number.set_value(0.5)
+    assert app.storage.general["temperature_override"] == 0.5
+    user.find(marker="button_reset_temperature").click()
+    assert number.value is None
+    assert app.storage.general["temperature_override"] is None
+
+
+# --- input_initial_prompt: textarea binds to storage --------------------
+
+
+async def test_input_initial_prompt_binds_to_storage(user: User, cuda_available):
+    await _open_dialog(user)
+    await user.should_see("Initial Prompt", retries=100)
+    textarea = _last(user, "textarea_initial_prompt")
+    textarea.set_value("hello world")
+    assert app.storage.general["initial_prompt"] == "hello world"


### PR DESCRIPTION
Sister to #181 — same shape of coverage applied to the five inputs inside the `advanced_settings` dialog that #181 explicitly left out (it called them out as a separate follow-up because they sit behind a dialog and lazy-import `torch.cuda`).

## What this adds

`tests/ui/test_advanced_settings.py` — eight NiceGUI `user`-fixture tests:

- `test_input_gpu_storage_seeded_false_when_no_cuda` — with `torch.cuda.is_available` mocked False, `input_gpu` writes `storage["GPU"] = False` as a render-time side effect; assert it landed (no dialog open needed — the embedded closed dialog also runs `input_gpu`)
- `test_input_gpu_switch_defaults_to_true_with_cuda` — with CUDA mocked available, the switch's initial `value` is `True`
- `test_input_gpu_toggle_writes_storage` — toggle the switch False/True/False, assert `storage["GPU"]` flips
- `test_input_compute_type_defaults_to_int8` — empty storage → `storage["compute_type"] == "int8"` after render
- `test_input_compute_type_options_restricted_when_gpu_off` — with GPU off, `set_compute_options()` collapses the select to `[INT8]` only; this is the cross-component test (GPU state drives the compute-type options)
- `test_input_cpu_threads_default_and_reset` — number defaults to `DEFAULT_CPU_THREADS`; set to 8, click reset, assert back to default
- `test_input_temperature_default_none_and_reset` — number defaults to `None` ("auto"); set to 0.5, assert `storage["temperature_override"] == 0.5`, click reset, assert back to None
- `test_input_initial_prompt_binds_to_storage` — `textarea.set_value("hello world")`, assert `storage["initial_prompt"] == "hello world"`

## Small source changes for robust widget selection

Six `.mark(...)` additions in `aTrain/components/settings/advanced.py` plus one on the settings button in `aTrain/pages/transcribe.py`, mirroring the #181 pattern:

- `switch_gpu`, `number_cpu_threads`, `button_reset_cpu_threads`, `number_temperature`, `button_reset_temperature`, `textarea_initial_prompt` — on the inputs
- `open_advanced_settings` — on the `Advanced Settings` button

The select inside `input_compute_type` already had `.mark("select_compute")`. All single-line additions; no behaviour change.

## Housekeeping

Adds `.vscode` to `.gitignore` so personal editor configs and debug-scratch files (e.g. local `launch.json`, breakpoint helpers) stay out of the repo.

## Determinism: mocking torch.cuda

`input_gpu` lazy-imports `from torch import cuda` and branches on `cuda.is_available()`. To get the same coverage on CPU-only and GPU runners, the tests use two fixtures (`no_cuda` / `cuda_available`) that monkeypatch `torch.cuda.is_available`. Without this, `test_input_compute_type_options_restricted_when_gpu_off` would silently pass on CPU runners and silently fail on GPU runners.

## Multi-dialog quirk (worth knowing for the reviewer)

The transcribe page mounts `advanced_settings(open=False)` (embedded closed dialog) and the settings button creates a new `advanced_settings(open=True)` on each click. After clicking, there are two instances of every input under the same marker. The tests use a small `_last(user, marker)` helper to pick the freshly opened one for value assertions; for buttons the wrapper API (`user.find(marker=...).click()`) clicks the first match, but the `set_value` lambda flows through `bind_value` to storage and back to all bound numbers, so the assertion holds either way. Both paths are commented inline.

## Storage / binding isolation

Same as #181: storage and bindings are reset automatically by NiceGUI's `nicegui_reset_globals` fixture (autouse via the `user` chain). No per-test cleanup needed.

## CI

Lives in `tests/ui`, runs in the existing `e2e (app, full stack)` job alongside the click-through and the #181 settings tests.

## Test plan

- `e2e (app, full stack)` job green (includes `pytest tests/ui` — the 8 new tests plus existing ones)
- existing jobs (`ruff`, `bandit`, `pip-audit`, `unit` ubuntu+windows, `e2e (core pipeline)`) stay green (no `uv.lock` or app-runtime changes)
- locally: `pytest tests/ui/test_advanced_settings.py -v` → 8 passed in ~7s

## Maps to BSI IT-Grundschutz

- CON.8 §3.2.5 (Funktionstests und Sicherheitstests) — closes the coverage gap #181 left open on the advanced-settings dialog, with extra rigour around the GPU/compute interplay.

## Related

- Sister: #181 (always-visible transcribe-page settings)
- Predecessors: #172 (E2E suite) / #176 (unit tests / windows matrix) / #180 (page render smokes) / #182 (archive + models interactions)
- Proposal / discussion: #171

cc @gerardo-navarro