### PR TITLE
Bugfix extend ci timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
   e2e:
     name: e2e (core pipeline)
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 45
 
     steps:
       - name: Checkout
@@ -132,7 +132,7 @@ jobs:
   e2e-app:
     name: e2e (app, full stack)
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 45
 
     steps:
       - name: Checkout

--- a/dev.py
+++ b/dev.py
@@ -1,5 +1,6 @@
 import os
 from unittest.mock import patch
+
 from aTrain_core.globals import ATRAIN_DIR, FLATPAK
 from platformdirs import user_config_path
 
@@ -7,8 +8,14 @@ from platformdirs import user_config_path
 NICEGUI_STORAGE_PATH = user_config_path() / "aTrain" if FLATPAK else (ATRAIN_DIR / "settings")
 
 with patch.dict(os.environ, NICEGUI_STORAGE_PATH=str(NICEGUI_STORAGE_PATH)):
+    from aTrain.pages import (  # noqa: F401  # Registers the UI pages
+        about,
+        archive,
+        faq,
+        models,
+        transcribe,
+    )
     from nicegui import ui
-    from aTrain.pages import about, archive, faq, models, transcribe  # Registers the UI pages
 
     if __name__ in {"__main__", "__mp_main__"}:
         ui.run(

--- a/dev.py
+++ b/dev.py
@@ -1,0 +1,18 @@
+import os
+from unittest.mock import patch
+from aTrain_core.globals import ATRAIN_DIR, FLATPAK
+from platformdirs import user_config_path
+
+# Setup the NiceGUI storage path, mimicking the native app behavior
+NICEGUI_STORAGE_PATH = user_config_path() / "aTrain" if FLATPAK else (ATRAIN_DIR / "settings")
+
+with patch.dict(os.environ, NICEGUI_STORAGE_PATH=str(NICEGUI_STORAGE_PATH)):
+    from nicegui import ui
+    from aTrain.pages import about, archive, faq, models, transcribe  # Registers the UI pages
+
+    if __name__ in {"__main__", "__mp_main__"}:
+        ui.run(
+            native=False,
+            reload=True,
+            title="aTrain (Dev Mode)",
+        )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       # `docker compose exec atrain rm ...` or sudo. data/ is git- and
       # docker-ignored.
       - ./data:/root/.local/share/aTrain
+    command: python dev.py
     environment:
       # Prevents Python from buffering stdout/stderr (cleaner container logs)
       - PYTHONUNBUFFERED=1


### PR DESCRIPTION
## Summary

Increase timout for CI runs, to acount for wer test taking multiple 10 minute runs in rare cases.

Add dev.py file and add to docker-compose.yml 
