### PR TITLE
Extend FLATPAK filepicker portal to LINUX

### DIFF
--- a/aTrain/components/settings/file.py
+++ b/aTrain/components/settings/file.py
@@ -1,6 +1,6 @@
 import os
 
-from aTrain_core.globals import FLATPAK
+from aTrain_core.globals import FLATPAK, LINUX
 from aTrain_core.settings import load_formats
 from nicegui import ui
 
@@ -41,7 +41,7 @@ def input_file() -> CustomUpload:
             select_button.props("unelevated no-caps :ripple=false")
             select_button.classes("w-full h-full")
 
-    if not FLATPAK:
+    if not (FLATPAK or LINUX):
         select_button.bind_text(uploader, "file_text")
         select_button.bind_icon(uploader, "file_icon")
         select_button.on_click(uploader.pick_files)

--- a/aTrain/pages/transcribe.py
+++ b/aTrain/pages/transcribe.py
@@ -10,7 +10,7 @@ from aTrain.components.settings.speaker_detection import input_speaker_detection
 from aTrain.components.splash_screen import splash_screen
 from aTrain.layouts.base import base_layout
 from aTrain.utils.transcription import start_transcription
-from aTrain_core.globals import FLATPAK
+from aTrain_core.globals import FLATPAK, LINUX
 from nicegui import Client, ui
 
 
@@ -33,7 +33,7 @@ async def page(client: Client):
                 "open_advanced_settings"
             )
             settings_btn.props("size=0.8rem unelevated no-caps icon=settings")
-            if FLATPAK:
+            if FLATPAK or LINUX:
 
                 async def start_from_selected():
                     if not getattr(file, "selected_path", None):
@@ -51,6 +51,6 @@ async def page(client: Client):
             start_btn.props("no-caps unelevated")
             advanced_settings(open=False)
 
-    if not FLATPAK:
+    if not (FLATPAK or LINUX):
         file.on_upload(start_transcription)
     settings_btn.on_click(lambda: advanced_settings(open=True))

--- a/aTrain_core/globals.py
+++ b/aTrain_core/globals.py
@@ -9,6 +9,7 @@ from typing import cast
 from platformdirs import user_data_path, user_documents_path
 
 FLATPAK = bool(os.environ.get("FLATPAK_ID"))
+LINUX = platform.system().lower() == "linux"
 # pyannote requires an explicit opt-in/out for telemetry metrics
 if FLATPAK:
     os.environ.setdefault("PYANNOTE_METRICS_ENABLED", "false")


### PR DESCRIPTION
## Summary

The filepicker on native builds in LInux currently fails to open the system dialog. This pull request introduces a new flag LINUX that is then applied to the filepicker changes implemented that were currently only behind the FLATPAK flag (which uses the XDG Desktop Portal (File Chooser Portal). 

By adding the LINUX flag to the relevant sections with FLATPAK flags, behavior in FLATPAK and Windows remains unchanged.

## References
Closes https://github.com/aTrainTranscription/aTrain/issues/206

## Verification Steps

Build and tested locally on an Ubuntu 24.04 system.