### PR TITLE
fix: default PYANNOTE_METRICS_ENABLED to false for all runtimes

### DIFF
--- a/aTrain_core/globals.py
+++ b/aTrain_core/globals.py
@@ -9,9 +9,11 @@ from typing import cast
 from platformdirs import user_data_path, user_documents_path
 
 FLATPAK = bool(os.environ.get("FLATPAK_ID"))
-# pyannote requires an explicit opt-in/out for telemetry metrics
-if FLATPAK:
-    os.environ.setdefault("PYANNOTE_METRICS_ENABLED", "false")
+# pyannote requires an explicit opt-in/out for telemetry metrics and raises
+# ValueError on model load if unset. Default to opt-out for all runtimes
+# (Flatpak, MSIX, native pip on Linux/macOS/Windows, Docker); `setdefault`
+# respects an explicitly-set env var if an operator wants metrics on.
+os.environ.setdefault("PYANNOTE_METRICS_ENABLED", "false")
 
 # Keep `spawn` for Flatpak x86; avoid forcing it on Flatpak ARM.
 if FLATPAK and platform.machine().lower() not in {"aarch64", "arm64"}:


### PR DESCRIPTION

Surfaced on multiple subjects, e.g. whene smoke-testing @JuergenFleiss's #207 end-to-end on my Zorin OS 17.3 machine(non-Flatpak). As soon as speaker detection ran, the transcription crashed with:

```
File ".../pyannote/audio/telemetry/metrics.py", line 190, in is_metrics_enabled
    raise ValueError("PYANNOTE_METRICS_ENABLED environment variable is not set.")
```

As mentioned in previous discussions, pyannote.audio 4.x now requires an explicit opt-in/out via the `PYANNOTE_METRICS_ENABLED` env var and raises `ValueError` on model load if unset. `aTrain_core/globals.py` previously defaulted it only inside the `if FLATPAK:` branch, so non-Flatpak runtimes hit the raise: native pip on Linux/macOS/Windows, MSIX, Docker without the env in docker-compose.

Move the `setdefault` out of the FLATPAK conditional so every runtime opts out by default. `setdefault` respects an explicit user setting, so operators who want metrics on can still export the var.

Verified locally on my machine with speaker detection enabled: transcription completes without the ValueError.

cc @gerardo-navarro
