### PR TITLE
fix: exclude aTrain/required_models from Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -30,3 +30,7 @@ docs/
 # Dev-container runtime output (models + transcriptions); bind-mounted at
 # runtime, must not enter the build context.
 data/
+
+# Bundled Whisper/pyannote models (~1.5 GB); downloaded at runtime, not needed
+# in the build context.
+aTrain/required_models/


### PR DESCRIPTION
The bundled Whisper/pyannote models (~1.5 GB) were transferred as part of the Docker build context, inflating it to ~1.67 GB even though the source tree is small. Models are downloaded at runtime, so they do not belong in the image build context.

## Summary

Adds `aTrain/required_models/` to `.dockerignore` so the bundled models are excluded from the Docker build context.

- The `aTrain/required_models/` directory holds the Whisper/pyannote models (~1.5 GB) and is the bulk of the 1.67 GB build context.
- These models are downloaded at runtime, so they are not needed when building the base or dev image.
- Excluding the directory shrinks the transferred context to a few MB and speeds up `docker compose build`.

## References

<!-- e.g. Closes #123, Refs #456 -->

## Screenshots / Examples

Build context **before** the change (~1.67 GB):

```
=> [internal] load build context
=> => transferring context: 1.67GB    6.4s
```

Build context **after** the change (~16.85 MB):

```
=> [internal] load .dockerignore
=> => transferring context: 542B
=> [internal] load build context
=> => transferring context: 16.85MB    0.1s
```

## Verification Steps

1. `docker compose -f docker-compose.yml -f .devcontainer/docker-compose.devcontainer.yml build --no-cache base`
2. In the build log, confirm the `transferring context:` line now reports a few MB instead of ~1.67 GB.
3. Confirm the base and dev images still build successfully.
