### PR TITLE
README.md: Link to additional download types

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,16 @@
 ## Accessible Transcription of Interviews
 aTrain is a tool for automatically transcribing speech recordings utilizing state-of-the-art machine learning models without uploading any data. It was developed by researchers at the Business Analytics and Data Science-Center at the University of Graz and tested by researchers from the Know-Center Graz.
 
-
+## Get aTrain
 <p>
   <a href="https://flathub.org/apps/io.github.juergenfleiss.aTrain">
-    <img height="58" alt="Get it on Flathub" src="https://flathub.org/api/badge?locale=en">
-  </a>
+    <img height="58" alt="Get it on Flathub" src="https://flathub.org/api/badge?locale=en"></a>
   &nbsp;&nbsp;
   <a href="https://apps.microsoft.com/detail/9N15Q44SZNS2?mode=direct">
-    <img width="220" alt="Get it from Microsoft" src="https://get.microsoft.com/images/en-us%20dark.svg">
-  </a>
+    <img width="220" alt="Get it from Microsoft" src="https://get.microsoft.com/images/en-us%20dark.svg"></a>
 </p>
 
+aTrain is published on Flathub for Linux and the Microsoft Store for Windows.  Additional download types [can be found here](https://business-analytics.uni-graz.at/de/forschung/atrain/download/).
 
 
 ## About aTrain


### PR DESCRIPTION
## Summary

Make it easy to find the alternative downloads (e.g. .deb and direct MSIX downloads).

(Also, the closing `</a>` tag was put right after the `img` element for the two image-buttons, to avoid a small spurious blue underline showing up.)

## References

Refs https://github.com/aTrainTranscription/aTrain/issues/103#issuecomment-4620384466

## Screenshots / Examples

<img width="1048" height="558" alt="image" src="https://github.com/user-attachments/assets/d563fafb-93f7-4143-bd67-b99e51c750c5" />

## Verification Steps

N/A