### PR TITLE
docs: add publiccode.yml for OpenCode Software-Verzeichnis

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -93,7 +93,7 @@ description:
     longDescription: >
       aTrain transkribiert Sprachaufnahmen automatisch mit modernen
       Machine-Learning-Modellen, ohne dass Daten hochgeladen werden.
-      Entwickelt wurde die Software von Forschenden am Business Analytics and
+     Entwickelt wurde die Software von Forschenden am Center for Data Science in Business and Society
       Data Science-Center der Universität Graz und getestet von Forschenden am
       Know-Center Graz.
 

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -137,7 +137,7 @@ description:
 
 legal:
   license: AGPL-3.0-or-later # TODO(opencode): confirm this is on OpenCode's permitted-licenses list.
-  mainCopyrightOwner: University of Graz
+  mainCopyrightOwner: Jürgen Fleiß
 
 maintenance:
   type: community

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -131,7 +131,7 @@ description:
       - share/screenshots/screenshot_5.png
 
 legal:
-  license: AGPL-3.0-or-later # TODO(opencode): confirm this is on OpenCode's permitted-licenses list.
+  license: AGPL-3.0-or-later
   mainCopyrightOwner: Jürgen Fleiß
 
 maintenance:

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -94,7 +94,7 @@ description:
       aTrain transkribiert Sprachaufnahmen automatisch mit modernen
       Machine-Learning-Modellen, ohne dass Daten hochgeladen werden.
      Entwickelt wurde die Software von Forschenden am Center for Data Science in Business and Society
-      Data Science-Center der Universität Graz und getestet von Forschenden am
+       der Universität Graz und getestet von Forschenden am
       Know-Center Graz.
 
 

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -1,7 +1,7 @@
 # This repository adheres to the publiccode.yml standard by including this
 # metadata file that makes public software easily discoverable.
 # More info at https://github.com/italia/publiccode.yml
-publiccodeYmlVersion: "0.4" # TODO(opencode): confirm the version editor.opencode.de expects.
+publiccodeYmlVersion: "0.4"
 
 name: aTrain
 url: "https://github.com/aTrainTranscription/aTrain"

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -13,7 +13,7 @@ url: "https://github.com/aTrainTranscription/aTrain"
 landingURL: "https://business-analytics.uni-graz.at/en/research/atrain/"
 
 softwareVersion: "1.5.0"
-releaseDate: "2026-01-28" # TODO: date of the 1.5.0 public release; 2026-01-28 is the v1.4.1 tag date.
+releaseDate: "2026-01-28"
 
 logo: docs/images/logo.svg
 

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -46,7 +46,7 @@ description:
     longDescription: >
       aTrain automatically transcribes speech recordings using
       state-of-the-art machine-learning models, without uploading any data.
-      It was developed by researchers at the Business Analytics and Data
+      It was developed by researchers at the Center for Data Science in Business and Society
        at the University of Graz and tested by researchers at
       the Know-Center Graz.
 

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -47,7 +47,7 @@ description:
       aTrain automatically transcribes speech recordings using
       state-of-the-art machine-learning models, without uploading any data.
       It was developed by researchers at the Business Analytics and Data
-      Science-Center at the University of Graz and tested by researchers at
+       at the University of Graz and tested by researchers at
       the Know-Center Graz.
 
 

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -1,0 +1,160 @@
+# publiccode.yml — metadata for the OpenCode Software-Verzeichnis.
+# Standard: https://yml.publiccode.tools/  |  Guide: https://guide.opencode.de/
+# Validate at https://editor.opencode.de before submitting.
+#
+# TODO(opencode): OpenCode lists software from repositories on
+# https://gitlab.opencode.de/. A mirror of this repo there does NOT exist yet.
+# Once the mirror is created, switch `url` (and screenshot/logo hosting) to the
+# GitLab repo. Until then `url` points at the canonical GitHub repo.
+publiccodeYmlVersion: "0.4" # TODO(opencode): confirm the version editor.opencode.de expects.
+
+name: aTrain
+url: "https://github.com/aTrainTranscription/aTrain"
+landingURL: "https://business-analytics.uni-graz.at/en/research/atrain/"
+
+softwareVersion: "1.5.0"
+releaseDate: "2026-01-28" # TODO: date of the 1.5.0 public release; 2026-01-28 is the v1.4.1 tag date.
+
+logo: docs/images/logo.svg
+
+platforms:
+  - windows
+  - linux
+
+categories:
+  - data-collection
+  - knowledge-management
+
+developmentStatus: stable
+
+softwareType: standalone/desktop
+
+intendedAudience:
+  countries:
+    - de
+    - at
+  scope:
+    - research
+    - science-and-technology
+
+description:
+  en:
+    localisedName: aTrain
+    shortDescription: >-
+      Offline, GDPR-compliant transcription of speech recordings using
+      local Whisper machine-learning models.
+    longDescription: >
+      aTrain automatically transcribes speech recordings using
+      state-of-the-art machine-learning models, without uploading any data.
+      It was developed by researchers at the Business Analytics and Data
+      Science-Center at the University of Graz and tested by researchers at
+      the Know-Center Graz.
+
+
+      All processing runs completely offline on the user's own device. No
+      recording or transcription is ever sent to the internet, which helps
+      researchers meet data-privacy requirements from ethical guidelines and
+      comply with legal requirements such as the GDPR.
+
+
+      aTrain provides a user-friendly interface to the faster-whisper
+      implementation of OpenAI's Whisper model, delivering high transcription
+      quality across 99 languages. An optional speaker-detection mode based on
+      pyannote.audio assigns each text segment to a speaker. Transcripts export
+      directly into the common tools for qualitative analysis, ATLAS.ti,
+      MAXQDA and NVivo, letting researchers play the audio for a text segment
+      by clicking its timestamp.
+
+
+      aTrain runs on the CPU or, for a significant speed-up, on a CUDA-enabled
+      NVIDIA GPU. It is distributed through Flathub for Linux and the Microsoft
+      Store for Windows, and is also installable as a headless command-line
+      tool for automated transcription pipelines.
+    features:
+      - Automatic offline speech-to-text transcription
+      - Speaker detection and diarization
+      - Transcription in 99 languages
+      - GDPR-compliant, fully local processing
+      - Optional CUDA GPU acceleration
+      - Export to ATLAS.ti, MAXQDA and NVivo compatible formats
+      - Command-line interface for headless pipelines
+    documentation: "https://github.com/aTrainTranscription/aTrain/blob/main/docs/README.md"
+    screenshots:
+      - share/screenshots/screenshot_1.png
+      - share/screenshots/screenshot_2.png
+      - share/screenshots/screenshot_3.png
+      - share/screenshots/screenshot_4.png
+      - share/screenshots/screenshot_5.png
+  de:
+    localisedName: aTrain
+    shortDescription: >-
+      Offline und DSGVO-konforme Transkription von Sprachaufnahmen mit
+      lokalen Whisper-Machine-Learning-Modellen.
+    longDescription: >
+      aTrain transkribiert Sprachaufnahmen automatisch mit modernen
+      Machine-Learning-Modellen, ohne dass Daten hochgeladen werden.
+      Entwickelt wurde die Software von Forschenden am Business Analytics and
+      Data Science-Center der Universität Graz und getestet von Forschenden am
+      Know-Center Graz.
+
+
+      Die gesamte Verarbeitung läuft vollständig offline auf dem eigenen Gerät.
+      Weder Aufnahmen noch Transkriptionen werden ins Internet übertragen. Das
+      hilft Forschenden, Datenschutzanforderungen aus ethischen Richtlinien zu
+      erfüllen und rechtliche Vorgaben wie die DSGVO einzuhalten.
+
+
+      aTrain bietet eine benutzerfreundliche Oberfläche für die
+      faster-whisper-Implementierung des Whisper-Modells von OpenAI und liefert
+      hohe Transkriptionsqualität in 99 Sprachen. Ein optionaler
+      Sprechererkennungsmodus auf Basis von pyannote.audio ordnet jedem
+      Textabschnitt eine sprechende Person zu. Die Transkripte lassen sich
+      direkt in die gängigen Werkzeuge zur qualitativen Analyse importieren,
+      ATLAS.ti, MAXQDA und NVivo. Per Klick auf einen Zeitstempel wird das
+      zugehörige Audio abgespielt.
+
+
+      aTrain läuft auf der CPU oder, für eine deutliche Beschleunigung, auf
+      einer CUDA-fähigen NVIDIA-GPU. Die Software wird über Flathub für Linux
+      und den Microsoft Store für Windows bereitgestellt und ist zusätzlich als
+      Kommandozeilen-Werkzeug für automatisierte Transkriptions-Pipelines
+      installierbar.
+    features:
+      - Automatische Offline-Transkription (Sprache zu Text)
+      - Sprechererkennung und Diarisierung
+      - Transkription in 99 Sprachen
+      - DSGVO-konforme, vollständig lokale Verarbeitung
+      - Optionale CUDA-GPU-Beschleunigung
+      - Export in ATLAS.ti-, MAXQDA- und NVivo-kompatible Formate
+      - Kommandozeilen-Schnittstelle für Headless-Pipelines
+    documentation: "https://github.com/aTrainTranscription/aTrain/blob/main/docs/README.md"
+    screenshots:
+      - share/screenshots/screenshot_1.png
+      - share/screenshots/screenshot_2.png
+      - share/screenshots/screenshot_3.png
+      - share/screenshots/screenshot_4.png
+      - share/screenshots/screenshot_5.png
+
+legal:
+  license: AGPL-3.0-or-later # TODO(opencode): confirm this is on OpenCode's permitted-licenses list.
+  mainCopyrightOwner: University of Graz
+
+maintenance:
+  type: community
+  contacts:
+    - name: Jürgen Fleiß
+      email: "juergen.fleiss@uni-graz.at"
+      affiliation: University of Graz
+    - name: Armin Haberl
+      email: "armin.haberl@uni-graz.at"
+      affiliation: University of Graz
+
+localisation:
+  localisationReady: false
+  availableLanguages:
+    - en
+
+dependsOn:
+  hardware:
+    - name: NVIDIA CUDA-capable GPU
+      optional: true

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -1,11 +1,6 @@
-# publiccode.yml — metadata for the OpenCode Software-Verzeichnis.
-# Standard: https://yml.publiccode.tools/  |  Guide: https://guide.opencode.de/
-# Validate at https://editor.opencode.de before submitting.
-#
-# TODO(opencode): OpenCode lists software from repositories on
-# https://gitlab.opencode.de/. A mirror of this repo there does NOT exist yet.
-# Once the mirror is created, switch `url` (and screenshot/logo hosting) to the
-# GitLab repo. Until then `url` points at the canonical GitHub repo.
+# This repository adheres to the publiccode.yml standard by including this
+# metadata file that makes public software easily discoverable.
+# More info at https://github.com/italia/publiccode.yml
 publiccodeYmlVersion: "0.4" # TODO(opencode): confirm the version editor.opencode.de expects.
 
 name: aTrain


### PR DESCRIPTION
## Context

Adds a `publiccode.yml` at the repository root so aTrain can be listed in the [OpenCode Software-Verzeichnis](https://opencode.de/de/wissen/softwareverzeichnis/aufnahme-ins-softwareverzeichnis), the software directory for German public-sector open source.

## What this does

- New `publiccode.yml` (standard [v0.4](https://yml.publiccode.tools/)), metadata derived from the existing AppStream metainfo, `README`, `LICENSE`, and `pyproject.toml`.
- Descriptions in **English and German** (OpenCode recommends maintaining both; target audience is German-speaking public administration).
- License declared as `AGPL-3.0-or-later`, matching `LICENSE` and the AppStream metainfo.

## Key metadata choices

| Field | Value | Rationale |
|-------|-------|-----------|
| `url` | `github.com/aTrainTranscription/aTrain` | Canonical repo. Placeholder until the openCode GitLab mirror exists (see below). |
| `categories` | `data-collection`, `knowledge-management` | The publiccode vocabulary has no audio/transcription slug; these are the closest controlled values. |
| `softwareType` | `standalone/desktop` | Native pywebview desktop app is the primary product. |
| `developmentStatus` | `stable` | Published on Flathub and the Microsoft Store. |
| `localisation` | `localisationReady: false`, `[en]` | UI strings are hardcoded English; no i18n framework. |

## Open items before the directory listing is live

These do not block review of the file itself, but must be resolved before submission. Each is marked with a `TODO(opencode)` comment in the file:

- [ ] **openCode GitLab mirror** — OpenCode lists software from repositories on `gitlab.opencode.de`. A mirror of this repo there does not exist yet. Once created, `url` and the relative asset paths point at the GitLab repo. **Maintainer action.**
- [ ] **`publiccodeYmlVersion`** — set to `0.4`; confirm the value the [editor.opencode.de](https://editor.opencode.de) validator expects.
- [x] **License allow-list** — confirm `AGPL-3.0-or-later` is on OpenCode's [permitted-licenses list](https://opencode.de/en/knowledge/general-conditions/standardised-open-source-licenses).
- [ ] **`releaseDate`** — currently `2026-01-28` (the v1.4.1 tag date); update to the real 1.5.0 release date.

## Test plan

- [x] File parses as YAML (UTF-8, YAML 1.2).
- [x] `shortDescription` ≤ 150 chars, `longDescription` ≥ 150 chars, 5–20 features (both languages).
- [ ] Validate via [editor.opencode.de](https://editor.opencode.de) "Validate" button once the GitLab mirror URL is final.

## Note (out of scope)

`CITATION.cff` declares `license: MIT`, which contradicts the `AGPL-3.0-or-later` in `LICENSE`. Worth a separate fix.
