### PR TITLE
fix: fall back to writable MODELS_DIR when packaged required_models is absent

### DIFF
--- a/aTrain/utils/models.py
+++ b/aTrain/utils/models.py
@@ -16,7 +16,9 @@ from nicegui.run import setup as setup_process_pool
 
 
 def read_downloaded_models() -> list:
-    directories_to_search = [MODELS_DIR, REQUIRED_MODELS_DIR]
+    # The two dirs coincide when REQUIRED_MODELS_DIR falls back to MODELS_DIR
+    # (no bundled models); dedupe so models aren't listed twice.
+    directories_to_search = list(dict.fromkeys([MODELS_DIR, REQUIRED_MODELS_DIR]))
     all_downloaded_models = []
 
     for directory in directories_to_search:

--- a/aTrain_core/globals.py
+++ b/aTrain_core/globals.py
@@ -42,7 +42,7 @@ elif find_spec("aTrain"):
     # Same fallback as the Flatpak branch above: only use the in-package dir
     # when it actually ships models. The install location can be read-only
     # (MSIX under C:\Program Files\WindowsApps\), so a missing dir must not
-    # be created there at runtime — downloads go to the writable MODELS_DIR.
+    # be created there at runtime - downloads go to the writable MODELS_DIR.
     packaged_required_models_dir = cast(Path, files("aTrain") / "required_models")
     REQUIRED_MODELS_DIR = (
         packaged_required_models_dir if packaged_required_models_dir.is_dir() else MODELS_DIR

--- a/aTrain_core/globals.py
+++ b/aTrain_core/globals.py
@@ -39,7 +39,14 @@ if FLATPAK:
         flatpak_required_models_dir if flatpak_required_models_dir.is_dir() else MODELS_DIR
     )
 elif find_spec("aTrain"):
-    REQUIRED_MODELS_DIR = cast(Path, files("aTrain") / "required_models")
+    # Same fallback as the Flatpak branch above: only use the in-package dir
+    # when it actually ships models. The install location can be read-only
+    # (MSIX under C:\Program Files\WindowsApps\), so a missing dir must not
+    # be created there at runtime — downloads go to the writable MODELS_DIR.
+    packaged_required_models_dir = cast(Path, files("aTrain") / "required_models")
+    REQUIRED_MODELS_DIR = (
+        packaged_required_models_dir if packaged_required_models_dir.is_dir() else MODELS_DIR
+    )
 else:
     REQUIRED_MODELS_DIR = MODELS_DIR
 

--- a/tests/ui/test_read_downloaded_models.py
+++ b/tests/ui/test_read_downloaded_models.py
@@ -1,0 +1,31 @@
+"""Tests for aTrain/utils/models.py::read_downloaded_models.
+
+Pure filesystem-scanning behaviour — no NiceGUI page involved, but the
+module imports nicegui, so these live with the app-runtime suite rather
+than tests/unit. The search dirs are rebound on the models module (which
+imports them into its own namespace via `from aTrain_core.globals import`).
+"""
+
+from aTrain.utils import models
+
+
+def _make_model_dir(root, name):
+    model_dir = root / name
+    model_dir.mkdir(parents=True)
+    (model_dir / "model.bin").touch()
+
+
+def test_finds_model_with_bin_file(tmp_path, monkeypatch):
+    _make_model_dir(tmp_path / "models", "large-v3-turbo")
+    monkeypatch.setattr(models, "MODELS_DIR", tmp_path / "models")
+    monkeypatch.setattr(models, "REQUIRED_MODELS_DIR", tmp_path / "required")
+    assert models.read_downloaded_models() == ["large-v3-turbo"]
+
+
+def test_no_duplicates_when_dirs_coincide(tmp_path, monkeypatch):
+    # REQUIRED_MODELS_DIR falls back to MODELS_DIR when no models are
+    # bundled with the package; the same dir must not be scanned twice.
+    _make_model_dir(tmp_path / "models", "large-v3-turbo")
+    monkeypatch.setattr(models, "MODELS_DIR", tmp_path / "models")
+    monkeypatch.setattr(models, "REQUIRED_MODELS_DIR", tmp_path / "models")
+    assert models.read_downloaded_models() == ["large-v3-turbo"]

--- a/tests/unit/test_globals.py
+++ b/tests/unit/test_globals.py
@@ -1,0 +1,51 @@
+"""Unit tests for aTrain_core.globals' REQUIRED_MODELS_DIR resolution.
+
+The constant is computed at import time, so each test re-executes the module
+body via importlib.reload with `files("aTrain")` pointed at an isolated temp
+dir. Torch- and NiceGUI-free, so they run in the lightweight `unit` CI job.
+"""
+
+import importlib
+import importlib.resources
+from pathlib import Path
+
+import aTrain_core.globals
+import pytest
+
+
+@pytest.fixture
+def reload_globals(monkeypatch, tmp_path):
+    """Return a function that reloads aTrain_core.globals with `files("aTrain")`
+    resolving to the given path. FLATPAK_ID is cleared and ATRAIN_USER_DIR is
+    redirected so the reload never touches the real user environment. The
+    pristine module is restored on teardown."""
+
+    def _reload(packaged_dir: Path):
+        real_files = importlib.resources.files
+
+        def fake_files(package):
+            return packaged_dir if package == "aTrain" else real_files(package)
+
+        monkeypatch.delenv("FLATPAK_ID", raising=False)
+        monkeypatch.setenv("ATRAIN_USER_DIR", str(tmp_path / "user"))
+        monkeypatch.setattr(importlib.resources, "files", fake_files)
+        return importlib.reload(aTrain_core.globals)
+
+    yield _reload
+    monkeypatch.undo()
+    importlib.reload(aTrain_core.globals)
+
+
+def test_required_models_dir_uses_packaged_dir_when_it_exists(reload_globals, tmp_path):
+    packaged = tmp_path / "aTrain" / "required_models"
+    packaged.mkdir(parents=True)
+    module = reload_globals(tmp_path / "aTrain")
+    assert packaged == module.REQUIRED_MODELS_DIR
+
+
+def test_required_models_dir_falls_back_to_models_dir_when_missing(reload_globals, tmp_path):
+    # No required_models dir inside the package location — e.g. an MSIX
+    # without pre-populated models, where the install path is read-only and
+    # must never be written to.
+    module = reload_globals(tmp_path / "aTrain")
+    assert module.REQUIRED_MODELS_DIR == module.MODELS_DIR


### PR DESCRIPTION
Follow-up to #216 (the "cleaner long-term fix" mentioned there). Fixes the crash class behind the MSIX pre-population requirement.

### Problem

`REQUIRED_MODELS_DIR` resolves to `<installed aTrain package>/required_models` unconditionally. Under MSIX that path is read-only (`C:\Program Files\WindowsApps\...`); if the dir wasn't baked in at build time, `os.makedirs` in `read_downloaded_models` (or a first-run model download) crashes with `PermissionError [WinError 5]` and blocks page render.

### Fix

Apply the same existence check the Flatpak branch directly above already uses: bundled dir exists -> use it (read-only is fine, nothing writes there); otherwise fall back to the writable `MODELS_DIR`, so required models download on first run like any other model.

Also dedupes the search list in `read_downloaded_models` so models aren't listed twice when both dirs coincide - already reachable today via the Flatpak fallback path.

### Effect on packaging

- A slim MSIX (no models baked in) now works: first run downloads to the user-writable models dir. Bundle drops from ~4 GB to ~2 GB, back under GitHub's release-asset limit.
- Pre-populated MSIX / Flatpak builds are unaffected: bundled dir exists -> used as before.
- Normal pip/uv installs: new installs store required models in `MODELS_DIR` (Documents) instead of site-packages, so they survive package upgrades. Existing installs with models already in site-packages keep working (dir exists -> used).

### Tests

- `tests/unit/test_globals.py` - resolution logic both ways (packaged dir exists / missing), via module reload with `files("aTrain")` pointed at a temp dir.
- `tests/ui/test_read_downloaded_models.py` - scan behaviour + no duplicates when the dirs coincide.

cc @gerardo-navarro
