### PR TITLE
ci: upload the installer to Zenodo as a draft record

### DIFF
--- a/.github/scripts/zenodo-upload.sh
+++ b/.github/scripts/zenodo-upload.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+#
+# Upload release artifacts to Zenodo as a DRAFT deposition. Never publishes -
+# a maintainer reviews and publishes in the Zenodo UI, which also submits the
+# record to the community.
+#
+# Usage:
+#   zenodo-upload.sh <version> <file>...
+#
+# Environment:
+#   ZENODO_TOKEN        (required) personal access token, scope deposit:write
+#   ZENODO_BASE         (required) https://zenodo.org or https://sandbox.zenodo.org
+#   GITHUB_REPOSITORY   (required) owner/name, used for the release back-link
+#   ZENODO_CONCEPT_ID   (optional) concept id of the published record; when set,
+#                       the upload is added as a new version of it, otherwise a
+#                       new concept is started
+#   ZENODO_METADATA     (optional) metadata file, defaults to .zenodo.json
+#
+# Example (rehearse against the sandbox):
+#   ZENODO_TOKEN=... ZENODO_BASE=https://sandbox.zenodo.org \
+#   GITHUB_REPOSITORY=aTrainTranscription/aTrain \
+#     .github/scripts/zenodo-upload.sh 1.5.0 aTrain-1.5.0.msix checksums.txt
+#
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: zenodo-upload.sh <version> <file>...
+
+Uploads the files to Zenodo as a draft deposition. Never publishes.
+
+Environment:
+  ZENODO_TOKEN       (required) token with scope deposit:write
+  ZENODO_BASE        (required) https://zenodo.org | https://sandbox.zenodo.org
+  GITHUB_REPOSITORY  (required) owner/name, for the release back-link
+  ZENODO_CONCEPT_ID  (optional) concept id; when set, adds a new version to it
+  ZENODO_METADATA    (optional) metadata file, default .zenodo.json
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then usage; exit 0; fi
+if [[ $# -lt 2 ]]; then usage >&2; exit 2; fi
+
+version="$1"; shift
+files=("$@")
+metadata_file="${ZENODO_METADATA:-.zenodo.json}"
+
+for var in ZENODO_TOKEN ZENODO_BASE GITHUB_REPOSITORY; do
+  if [[ -z "${!var:-}" ]]; then
+    echo "error: $var is not set - see $0 --help" >&2
+    exit 2
+  fi
+done
+[[ -f "$metadata_file" ]] || { echo "error: $metadata_file not found" >&2; exit 2; }
+for file in "${files[@]}"; do
+  [[ -f "$file" ]] || { echo "error: $file not found" >&2; exit 2; }
+done
+
+rendered_metadata="$(mktemp)"
+trap 'rm -f "$rendered_metadata"' EXIT
+
+# jq on Windows emits CRLF; the CR survives command substitution when the
+# output has several lines, and would end up inside request URLs.
+jqr() { jq -r "$@" | tr -d '\r'; }
+
+api() {  # api <method> <path-or-url> [curl args...]
+  local method="$1" url="$2"; shift 2
+  [[ "$url" == http* ]] || url="$ZENODO_BASE/api$url"
+  curl -sS --fail-with-body -X "$method" \
+    -H "Authorization: Bearer $ZENODO_TOKEN" "$@" "$url"
+}
+
+if [[ -n "${ZENODO_CONCEPT_ID:-}" ]]; then
+  # An unpublished draft blocks `newversion`, so reuse it - this release
+  # supersedes it anyway. `submitted == false` excludes the edit draft of an
+  # already published record, whose files cannot be deleted (403).
+  pending="$(api GET "/deposit/depositions?q=conceptrecid:$ZENODO_CONCEPT_ID&status=draft" \
+    | jqr '[.[] | select(.submitted == false)][0].id // empty')"
+  if [[ -n "$pending" ]]; then
+    echo "::warning::Zenodo draft $pending was still unpublished - reusing it for $version."
+    deposition="$(api GET "/deposit/depositions/$pending")"
+  else
+    # `newversion` needs the latest published version's id;
+    # /records/<concept> redirects there.
+    latest="$(curl -sSL --fail-with-body "$ZENODO_BASE/api/records/$ZENODO_CONCEPT_ID" | jqr '.id // empty')"
+    if [[ -z "$latest" ]]; then
+      echo "::error::ZENODO_CONCEPT_ID=$ZENODO_CONCEPT_ID does not resolve to a published record."
+      exit 1
+    fi
+    echo "adding a new version to concept $ZENODO_CONCEPT_ID (latest published: $latest)"
+    draft_url="$(api POST "/deposit/depositions/$latest/actions/newversion" | jqr .links.latest_draft)"
+    deposition="$(api GET "$draft_url")"
+  fi
+else
+  echo "no ZENODO_CONCEPT_ID set - creating the first record of a new concept"
+  deposition="$(api POST /deposit/depositions -H 'Content-Type: application/json' -d '{}')"
+fi
+
+id="$(jqr .id <<<"$deposition")"
+bucket="$(jqr .links.bucket <<<"$deposition")"
+
+# Drafts carry the previous version's files.
+for file_id in $(jqr '.files[]?.id' <<<"$deposition"); do
+  api DELETE "/deposit/depositions/$id/files/$file_id" -o /dev/null
+done
+
+# Bucket API: 50 GB per file. The legacy files endpoint caps at 100 MB.
+for file in "${files[@]}"; do
+  echo "uploading $file ($(du -h "$file" | cut -f1))"
+  api PUT "$bucket/$(basename "$file")" --upload-file "$file" -o /dev/null \
+    -w "  http=%{http_code} in %{time_total}s\n"
+done
+
+# Only the per-release bits are added here; the record metadata itself is
+# maintained in .zenodo.json, next to CITATION.cff.
+jq --arg v "$version" --arg repo "$GITHUB_REPOSITORY" '{metadata: (. + {
+  version: $v,
+  related_identifiers: (.related_identifiers + [{
+    identifier: "https://github.com/\($repo)/releases/tag/v\($v)",
+    relation: "isSupplementTo", scheme: "url"}])
+})}' "$metadata_file" > "$rendered_metadata"
+api PUT "/deposit/depositions/$id" -H 'Content-Type: application/json' \
+  -d @"$rendered_metadata" -o /dev/null -w "metadata http=%{http_code}\n"
+
+echo "::notice::Zenodo draft ready for review: $ZENODO_BASE/uploads/$id"
+if [[ -z "${ZENODO_CONCEPT_ID:-}" ]]; then
+  echo "::notice::First record - after publishing it, set the repo variable ZENODO_CONCEPT_ID to its concept id so later releases attach as new versions."
+fi

--- a/.github/scripts/zenodo-upload.sh
+++ b/.github/scripts/zenodo-upload.sh
@@ -7,6 +7,12 @@
 # Usage:
 #   zenodo-upload.sh <version> <file>...
 #
+# One invocation per release: it clears the draft's files before uploading,
+# so a second invocation for the same version would remove what the first one
+# uploaded. Once more artifact types exist (EXE #221, Flatpak), collect them
+# in a single publish job and pass them all to one invocation, rather than
+# calling this once per build job.
+#
 # Environment:
 #   ZENODO_TOKEN        (required) personal access token, scope deposit:write
 #   ZENODO_BASE         (required) https://zenodo.org or https://sandbox.zenodo.org
@@ -82,7 +88,12 @@ if [[ -n "${ZENODO_CONCEPT_ID:-}" ]]; then
   else
     # `newversion` needs the latest published version's id;
     # /records/<concept> redirects there.
-    latest="$(curl -sSL --fail-with-body "$ZENODO_BASE/api/records/$ZENODO_CONCEPT_ID" | jqr '.id // empty')"
+    # `if cmd` rather than a plain assignment: under `set -e` a failing curl
+    # would abort before the check below could report anything useful.
+    latest=""
+    if concept_record="$(curl -sSL --fail-with-body "$ZENODO_BASE/api/records/$ZENODO_CONCEPT_ID" 2>/dev/null)"; then
+      latest="$(jqr '.id // empty' <<<"$concept_record")"
+    fi
     if [[ -z "$latest" ]]; then
       echo "::error::ZENODO_CONCEPT_ID=$ZENODO_CONCEPT_ID does not resolve to a published record."
       exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,9 @@ jobs:
   build-windows-msix:
     name: Build Windows MSIX (unsigned)
     runs-on: windows-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      suffix: ${{ steps.version.outputs.suffix }}
     # Build ~13 min, plus ~13 min to push the 2.9 GB installer to Zenodo -
     # too close to the previous 30 min limit to absorb network variance.
     timeout-minutes: 60
@@ -163,25 +166,56 @@ jobs:
           # An MSIX is already a zip - re-compressing 2.9 GB buys nothing.
           compression-level: 0
 
+  publish:
+    name: Publish release artifacts
+    # Fan-in: the build jobs only produce artifacts, everything that talks to
+    # the outside world (GitHub release, Zenodo, signing later) happens here -
+    # once per release, with all artifacts in hand. Adding the EXE (#221) or
+    # Flatpak means adding a build job and listing it in `needs`.
+    needs: build-windows-msix
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: aTrain-*-${{ needs.build-windows-msix.outputs.version }}${{ needs.build-windows-msix.outputs.suffix }}
+          path: artifacts
+          merge-multiple: true
+
+      - name: Generate sha256 checksums
+        # Recomputed over the downloaded installers rather than reused from the
+        # build job, so the checksums also cover the artifact round-trip. One
+        # line per installer, so a consumer can verify a single download with
+        # `sha256sum -c checksums.txt --ignore-missing`.
+        working-directory: artifacts
+        run: |
+          checksums="checksums${{ needs.build-windows-msix.outputs.suffix }}.txt"
+          sha256sum aTrain-* > "$checksums"
+          cat "$checksums"
+
       - name: Attach checksums to the GitHub release
-        # The release is the integrity anchor, not the download channel:
-        # the MSIX itself exceeds GitHub's 2 GiB per-asset limit, so
-        # consumers fetch it from the workflow artifact / an external
-        # download and verify it against the sha256 published here.
-        # Signing material (#211) and the SBOM (#213) attach to the same
-        # anchor later.
+        # The release is the integrity anchor, not the download channel: the
+        # installers exceed GitHub's 2 GiB per-asset limit, so consumers fetch
+        # them from Zenodo (#229) or the workflow artifact and verify them
+        # against the sha256 published here. Signing material (#211) and the
+        # SBOM (#213) attach to the same anchor later.
         # Two flows are supported:
         # - release created via the GitHub UI (creates the tag on publish,
         #   which triggers this run): upload to the existing release.
         # - tag pushed by hand: create a draft release so maintainers write
         #   notes and publish deliberately.
-        if: startsWith(github.ref, 'refs/tags/v')
-        shell: bash
+        working-directory: artifacts
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          version="${{ steps.version.outputs.version }}"
-          checksums="checksums${{ steps.version.outputs.suffix }}.txt"
+          version="${{ needs.build-windows-msix.outputs.version }}"
+          checksums="checksums${{ needs.build-windows-msix.outputs.suffix }}.txt"
           if gh release view "v$version" > /dev/null 2>&1; then
             gh release upload "v$version" "$checksums" --clobber
           else
@@ -193,13 +227,13 @@ jobs:
               "$checksums"
           fi
 
-      - name: Upload installer to Zenodo (draft)
-        # Zenodo is the download channel for the installer (#229). Creates a
+      - name: Upload installers to Zenodo (draft)
+        # Zenodo is the download channel for the installers (#229). Creates a
         # DRAFT only - a maintainer publishes it in the Zenodo UI, which also
-        # submits it to the community. Slim tag builds only.
+        # submits it to the community. Slim builds only: the bundled variant
+        # is an internal build, not a published release artifact.
         # The script is runnable locally, see `zenodo-upload.sh --help`.
-        if: startsWith(github.ref, 'refs/tags/v') && !inputs.bundle_models
-        shell: bash
+        if: ${{ !inputs.bundle_models }}
         env:
           ZENODO_TOKEN: ${{ secrets.ZENODO_TOKEN }}
           # No default on purpose: production vs sandbox is an explicit choice.
@@ -212,5 +246,5 @@ jobs:
             echo "::notice::No ZENODO_TOKEN configured - skipping the Zenodo upload."
             exit 0
           fi
-          version="${{ steps.version.outputs.version }}"
-          .github/scripts/zenodo-upload.sh "$version" "aTrain-$version.msix" checksums.txt
+          version="${{ needs.build-windows-msix.outputs.version }}"
+          .github/scripts/zenodo-upload.sh "$version" artifacts/aTrain-*.msix artifacts/checksums.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,14 +197,13 @@ jobs:
         # Zenodo is the download channel for the installer (#229). Creates a
         # DRAFT only - a maintainer publishes it in the Zenodo UI, which also
         # submits it to the community. Slim tag builds only.
+        # The script is runnable locally, see `zenodo-upload.sh --help`.
         if: startsWith(github.ref, 'refs/tags/v') && !inputs.bundle_models
         shell: bash
         env:
-          # The no-token skip lives in the script: `secrets` is unavailable in
-          # step `if` conditions, and the token stays scoped to this step.
           ZENODO_TOKEN: ${{ secrets.ZENODO_TOKEN }}
-          # Set to https://sandbox.zenodo.org to rehearse without real records.
-          ZENODO_BASE: ${{ vars.ZENODO_BASE || 'https://zenodo.org' }}
+          # No default on purpose: production vs sandbox is an explicit choice.
+          ZENODO_BASE: ${{ vars.ZENODO_BASE }}
           # The published record's `conceptrecid`, set once: every later
           # release is then added as a new version of that record.
           ZENODO_CONCEPT_ID: ${{ vars.ZENODO_CONCEPT_ID }}
@@ -213,73 +212,5 @@ jobs:
             echo "::notice::No ZENODO_TOKEN configured - skipping the Zenodo upload."
             exit 0
           fi
-
           version="${{ steps.version.outputs.version }}"
-          msix="aTrain-$version.msix"
-          checksums="checksums.txt"
-
-          api() {  # api <method> <path-or-url> [curl args...]
-            local method="$1" url="$2"; shift 2
-            [[ "$url" == http* ]] || url="$ZENODO_BASE/api$url"
-            curl -sS --fail-with-body -X "$method" \
-              -H "Authorization: Bearer $ZENODO_TOKEN" "$@" "$url"
-          }
-
-          if [[ -n "${ZENODO_CONCEPT_ID:-}" ]]; then
-            # An unpublished draft blocks `newversion`, so reuse it - this
-            # release supersedes it anyway.
-            # `submitted == false` excludes the edit draft of an already
-            # published record - deleting its files would fail with 403.
-            pending="$(api GET "/deposit/depositions?q=conceptrecid:$ZENODO_CONCEPT_ID&status=draft" \
-              | jq -r '[.[] | select(.submitted == false)][0].id // empty')"
-            if [[ -n "$pending" ]]; then
-              echo "::warning::Zenodo draft $pending was still unpublished - reusing it for $version."
-              deposition="$(api GET "/deposit/depositions/$pending")"
-            else
-              # `newversion` needs the latest published version's id;
-              # /records/<concept> redirects there.
-              latest="$(curl -sSL --fail-with-body "$ZENODO_BASE/api/records/$ZENODO_CONCEPT_ID" | jq -r '.id // empty')"
-              if [[ -z "$latest" ]]; then
-                echo "::error::ZENODO_CONCEPT_ID=$ZENODO_CONCEPT_ID does not resolve to a published record."
-                exit 1
-              fi
-              echo "adding a new version to concept $ZENODO_CONCEPT_ID (latest published: $latest)"
-              draft_url="$(api POST "/deposit/depositions/$latest/actions/newversion" | jq -r .links.latest_draft)"
-              deposition="$(api GET "$draft_url")"
-            fi
-            # Either way the draft carries the previous version's files.
-            # `tr -d '\r'`: jq on Windows emits CRLF, and the CR would survive
-            # word splitting into the request URL.
-            draft_id="$(jq -r .id <<<"$deposition")"
-            for file_id in $(jq -r '.files[]?.id' <<<"$deposition" | tr -d '\r'); do
-              api DELETE "/deposit/depositions/$draft_id/files/$file_id" -o /dev/null
-            done
-          else
-            echo "no ZENODO_CONCEPT_ID set - creating the first record of a new concept"
-            deposition="$(api POST /deposit/depositions -H 'Content-Type: application/json' -d '{}')"
-          fi
-          id="$(jq -r .id <<<"$deposition")"
-          bucket="$(jq -r .links.bucket <<<"$deposition")"
-
-          # Bucket API: 50 GB per file.
-          for file in "$msix" "$checksums"; do
-            echo "uploading $file ($(du -h "$file" | cut -f1))"
-            api PUT "$bucket/$file" --upload-file "$file" -o /dev/null \
-              -w "  http=%{http_code} in %{time_total}s\n"
-          done
-
-          # Record metadata lives in .zenodo.json, maintained next to
-          # CITATION.cff; only the per-release bits are added here.
-          jq --arg v "$version" --arg repo "$GITHUB_REPOSITORY" '{metadata: (. + {
-            version: $v,
-            related_identifiers: (.related_identifiers + [{
-              identifier: "https://github.com/\($repo)/releases/tag/v\($v)",
-              relation: "isSupplementTo", scheme: "url"}])
-          })}' .zenodo.json > metadata.json
-          api PUT "/deposit/depositions/$id" -H 'Content-Type: application/json' \
-            -d @metadata.json -o /dev/null -w "metadata http=%{http_code}\n"
-
-          echo "::notice::Zenodo draft ready for review: $ZENODO_BASE/uploads/$id"
-          if [[ -z "${ZENODO_CONCEPT_ID:-}" ]]; then
-            echo "::notice::First record - after publishing it, set the repo variable ZENODO_CONCEPT_ID to its concept id so later releases attach as new versions."
-          fi
+          .github/scripts/zenodo-upload.sh "$version" "aTrain-$version.msix" checksums.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,6 +188,16 @@ jobs:
           path: artifacts
           merge-multiple: true
 
+      - name: Add the source archive
+        # Keeps the record self-contained: the exact sources the installers
+        # were built from live next to them, at the same immutable place.
+        working-directory: artifacts
+        run: |
+          version="${{ needs.build-windows-msix.outputs.version }}"
+          curl -sSL --fail-with-body -o "aTrain-$version-source.tar.gz" \
+            "https://github.com/$GITHUB_REPOSITORY/archive/refs/tags/v$version.tar.gz"
+          ls -la
+
       - name: Generate sha256 checksums
         # Recomputed over the downloaded installers rather than reused from the
         # build job, so the checksums also cover the artifact round-trip. One
@@ -247,4 +257,4 @@ jobs:
             exit 0
           fi
           version="${{ needs.build-windows-msix.outputs.version }}"
-          .github/scripts/zenodo-upload.sh "$version" artifacts/aTrain-*.msix artifacts/checksums.txt
+          .github/scripts/zenodo-upload.sh "$version" artifacts/aTrain-* artifacts/checksums.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,6 +160,38 @@ jobs:
             aTrain-*.msix
             checksums*.txt
           if-no-files-found: error
+          # An MSIX is already a zip - re-compressing 2.9 GB buys nothing.
+          compression-level: 0
+
+      - name: Attach checksums to the GitHub release
+        # The release is the integrity anchor, not the download channel:
+        # the MSIX itself exceeds GitHub's 2 GiB per-asset limit, so
+        # consumers fetch it from the workflow artifact / an external
+        # download and verify it against the sha256 published here.
+        # Signing material (#211) and the SBOM (#213) attach to the same
+        # anchor later.
+        # Two flows are supported:
+        # - release created via the GitHub UI (creates the tag on publish,
+        #   which triggers this run): upload to the existing release.
+        # - tag pushed by hand: create a draft release so maintainers write
+        #   notes and publish deliberately.
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version="${{ steps.version.outputs.version }}"
+          checksums="checksums${{ steps.version.outputs.suffix }}.txt"
+          if gh release view "v$version" > /dev/null 2>&1; then
+            gh release upload "v$version" "$checksums" --clobber
+          else
+            gh release create "v$version" \
+              --draft \
+              --verify-tag \
+              --title "aTrain v$version" \
+              --generate-notes \
+              "$checksums"
+          fi
 
       - name: Upload installer to Zenodo (draft)
         # Zenodo is the download channel for the installer (#229). Creates a
@@ -196,14 +228,21 @@ jobs:
           if [[ -n "${ZENODO_CONCEPT_ID:-}" ]]; then
             # An unpublished draft blocks `newversion`, so reuse it - this
             # release supersedes it anyway.
-            pending="$(api GET "/deposit/depositions?q=conceptrecid:$ZENODO_CONCEPT_ID&status=draft&size=1" | jq -r '.[0].id // empty')"
+            # `submitted == false` excludes the edit draft of an already
+            # published record - deleting its files would fail with 403.
+            pending="$(api GET "/deposit/depositions?q=conceptrecid:$ZENODO_CONCEPT_ID&status=draft" \
+              | jq -r '[.[] | select(.submitted == false)][0].id // empty')"
             if [[ -n "$pending" ]]; then
               echo "::warning::Zenodo draft $pending was still unpublished - reusing it for $version."
               deposition="$(api GET "/deposit/depositions/$pending")"
             else
               # `newversion` needs the latest published version's id;
               # /records/<concept> redirects there.
-              latest="$(curl -sSL "$ZENODO_BASE/api/records/$ZENODO_CONCEPT_ID" | jq -r .id)"
+              latest="$(curl -sSL --fail-with-body "$ZENODO_BASE/api/records/$ZENODO_CONCEPT_ID" | jq -r '.id // empty')"
+              if [[ -z "$latest" ]]; then
+                echo "::error::ZENODO_CONCEPT_ID=$ZENODO_CONCEPT_ID does not resolve to a published record."
+                exit 1
+              fi
               echo "adding a new version to concept $ZENODO_CONCEPT_ID (latest published: $latest)"
               draft_url="$(api POST "/deposit/depositions/$latest/actions/newversion" | jq -r .links.latest_draft)"
               deposition="$(api GET "$draft_url")"
@@ -222,7 +261,7 @@ jobs:
           id="$(jq -r .id <<<"$deposition")"
           bucket="$(jq -r .links.bucket <<<"$deposition")"
 
-          # Bucket API: 50 GB per file. The legacy files endpoint caps at 100 MB.
+          # Bucket API: 50 GB per file.
           for file in "$msix" "$checksums"; do
             echo "uploading $file ($(du -h "$file" | cut -f1))"
             api PUT "$bucket/$file" --upload-file "$file" -o /dev/null \
@@ -243,34 +282,4 @@ jobs:
           echo "::notice::Zenodo draft ready for review: $ZENODO_BASE/uploads/$id"
           if [[ -z "${ZENODO_CONCEPT_ID:-}" ]]; then
             echo "::notice::First record - after publishing it, set the repo variable ZENODO_CONCEPT_ID to its concept id so later releases attach as new versions."
-          fi
-
-      - name: Attach checksums to the GitHub release
-        # The release is the integrity anchor, not the download channel:
-        # the MSIX itself exceeds GitHub's 2 GiB per-asset limit, so
-        # consumers fetch it from the workflow artifact / an external
-        # download and verify it against the sha256 published here.
-        # Signing material (#211) and the SBOM (#213) attach to the same
-        # anchor later.
-        # Two flows are supported:
-        # - release created via the GitHub UI (creates the tag on publish,
-        #   which triggers this run): upload to the existing release.
-        # - tag pushed by hand: create a draft release so maintainers write
-        #   notes and publish deliberately.
-        if: startsWith(github.ref, 'refs/tags/v')
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          version="${{ steps.version.outputs.version }}"
-          checksums="checksums${{ steps.version.outputs.suffix }}.txt"
-          if gh release view "v$version" > /dev/null 2>&1; then
-            gh release upload "v$version" "$checksums" --clobber
-          else
-            gh release create "v$version" \
-              --draft \
-              --verify-tag \
-              --title "aTrain v$version" \
-              --generate-notes \
-              "$checksums"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,9 @@ jobs:
   build-windows-msix:
     name: Build Windows MSIX (unsigned)
     runs-on: windows-latest
-    timeout-minutes: 30
+    # Build ~13 min, plus ~13 min to push the 2.9 GB installer to Zenodo -
+    # too close to the previous 30 min limit to absorb network variance.
+    timeout-minutes: 60
 
     steps:
       - name: Checkout
@@ -158,6 +160,90 @@ jobs:
             aTrain-*.msix
             checksums*.txt
           if-no-files-found: error
+
+      - name: Upload installer to Zenodo (draft)
+        # Zenodo is the download channel for the installer (#229). Creates a
+        # DRAFT only - a maintainer publishes it in the Zenodo UI, which also
+        # submits it to the community. Slim tag builds only.
+        if: startsWith(github.ref, 'refs/tags/v') && !inputs.bundle_models
+        shell: bash
+        env:
+          # The no-token skip lives in the script: `secrets` is unavailable in
+          # step `if` conditions, and the token stays scoped to this step.
+          ZENODO_TOKEN: ${{ secrets.ZENODO_TOKEN }}
+          # Set to https://sandbox.zenodo.org to rehearse without real records.
+          ZENODO_BASE: ${{ vars.ZENODO_BASE || 'https://zenodo.org' }}
+          # The published record's `conceptrecid`, set once: every later
+          # release is then added as a new version of that record.
+          ZENODO_CONCEPT_ID: ${{ vars.ZENODO_CONCEPT_ID }}
+        run: |
+          if [[ -z "${ZENODO_TOKEN:-}" ]]; then
+            echo "::notice::No ZENODO_TOKEN configured - skipping the Zenodo upload."
+            exit 0
+          fi
+
+          version="${{ steps.version.outputs.version }}"
+          msix="aTrain-$version.msix"
+          checksums="checksums.txt"
+
+          api() {  # api <method> <path-or-url> [curl args...]
+            local method="$1" url="$2"; shift 2
+            [[ "$url" == http* ]] || url="$ZENODO_BASE/api$url"
+            curl -sS --fail-with-body -X "$method" \
+              -H "Authorization: Bearer $ZENODO_TOKEN" "$@" "$url"
+          }
+
+          if [[ -n "${ZENODO_CONCEPT_ID:-}" ]]; then
+            # An unpublished draft blocks `newversion`, so reuse it - this
+            # release supersedes it anyway.
+            pending="$(api GET "/deposit/depositions?q=conceptrecid:$ZENODO_CONCEPT_ID&status=draft&size=1" | jq -r '.[0].id // empty')"
+            if [[ -n "$pending" ]]; then
+              echo "::warning::Zenodo draft $pending was still unpublished - reusing it for $version."
+              deposition="$(api GET "/deposit/depositions/$pending")"
+            else
+              # `newversion` needs the latest published version's id;
+              # /records/<concept> redirects there.
+              latest="$(curl -sSL "$ZENODO_BASE/api/records/$ZENODO_CONCEPT_ID" | jq -r .id)"
+              echo "adding a new version to concept $ZENODO_CONCEPT_ID (latest published: $latest)"
+              draft_url="$(api POST "/deposit/depositions/$latest/actions/newversion" | jq -r .links.latest_draft)"
+              deposition="$(api GET "$draft_url")"
+            fi
+            # Either way the draft carries the previous version's files.
+            # `tr -d '\r'`: jq on Windows emits CRLF, and the CR would survive
+            # word splitting into the request URL.
+            draft_id="$(jq -r .id <<<"$deposition")"
+            for file_id in $(jq -r '.files[]?.id' <<<"$deposition" | tr -d '\r'); do
+              api DELETE "/deposit/depositions/$draft_id/files/$file_id" -o /dev/null
+            done
+          else
+            echo "no ZENODO_CONCEPT_ID set - creating the first record of a new concept"
+            deposition="$(api POST /deposit/depositions -H 'Content-Type: application/json' -d '{}')"
+          fi
+          id="$(jq -r .id <<<"$deposition")"
+          bucket="$(jq -r .links.bucket <<<"$deposition")"
+
+          # Bucket API: 50 GB per file. The legacy files endpoint caps at 100 MB.
+          for file in "$msix" "$checksums"; do
+            echo "uploading $file ($(du -h "$file" | cut -f1))"
+            api PUT "$bucket/$file" --upload-file "$file" -o /dev/null \
+              -w "  http=%{http_code} in %{time_total}s\n"
+          done
+
+          # Record metadata lives in .zenodo.json, maintained next to
+          # CITATION.cff; only the per-release bits are added here.
+          jq --arg v "$version" --arg repo "$GITHUB_REPOSITORY" '{metadata: (. + {
+            version: $v,
+            related_identifiers: (.related_identifiers + [{
+              identifier: "https://github.com/\($repo)/releases/tag/v\($v)",
+              relation: "isSupplementTo", scheme: "url"}])
+          })}' .zenodo.json > metadata.json
+          api PUT "/deposit/depositions/$id" -H 'Content-Type: application/json' \
+            -d @metadata.json -o /dev/null -w "metadata http=%{http_code}\n"
+
+          echo "::notice::Zenodo draft ready for review: $ZENODO_BASE/uploads/$id"
+          if [[ -z "${ZENODO_CONCEPT_ID:-}" ]]; then
+            echo "::notice::First record - after publishing it, set the repo variable ZENODO_CONCEPT_ID to its concept id so later releases attach as new versions."
+          fi
 
       - name: Attach checksums to the GitHub release
         # The release is the integrity anchor, not the download channel:

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -8,7 +8,7 @@
     { "name": "Kowald, Dominik", "affiliation": "Know-Center Graz" },
     { "name": "Thalmann, Stefan", "affiliation": "University of Graz" }
   ],
-  "license": "agpl-3.0-or-later",
+  "license": "AGPL-3.0-or-later",
   "access_right": "open",
   "keywords": [
     "transcription",

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,35 @@
+{
+  "upload_type": "software",
+  "title": "aTrain - Accessible Transcription of Interviews",
+  "description": "<p>aTrain is a tool for automatically transcribing speech recordings utilizing state-of-the-art machine learning models without uploading any data. It provides a user-friendly interface to OpenAI's Whisper model, ensuring high-quality transcription while preserving data privacy by processing everything locally on the user's device.</p><p>This record contains the Windows installer (MSIX). Verify the download against the sha256 checksums published on the corresponding GitHub release.</p>",
+  "creators": [
+    { "name": "Haberl, Armin", "affiliation": "University of Graz" },
+    { "name": "Fleiß, Jürgen", "affiliation": "University of Graz" },
+    { "name": "Kowald, Dominik", "affiliation": "Know-Center Graz" },
+    { "name": "Thalmann, Stefan", "affiliation": "University of Graz" }
+  ],
+  "license": "agpl-3.0-or-later",
+  "access_right": "open",
+  "keywords": [
+    "transcription",
+    "speech-to-text",
+    "whisper",
+    "privacy-preserving",
+    "offline",
+    "interviews",
+    "qualitative-research"
+  ],
+  "communities": [{ "identifier": "atraintranscription" }],
+  "related_identifiers": [
+    {
+      "identifier": "10.1016/j.jbef.2024.100891",
+      "relation": "isDocumentedBy",
+      "scheme": "doi"
+    },
+    {
+      "identifier": "https://github.com/aTrainTranscription/aTrain",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ]
+}


### PR DESCRIPTION
Implements the hosting decision from #229, part of #212.

Tag builds now push the installer to Zenodo and stop at a **draft** - nothing is published automatically. A maintainer reviews it in the Zenodo UI and publishes, which also triggers the submission to the `aTrainTranscription` community. The GitHub release keeps the sha256 checksums as the verification anchor (#230), so a download can be verified no matter which channel it came from.

### Versioning

Releases are chained into one Zenodo concept, so they share a concept DOI that always resolves to the latest version - worth getting right from the start, because separately published records cannot be merged afterwards.

- `vars.ZENODO_CONCEPT_ID` **unset**: the first record of a new concept is created, and the run prints a reminder to set the variable afterwards.
- `vars.ZENODO_CONCEPT_ID` **set**: each release is added as a new version of that record.

Two API details the step works around, both found while rehearsing against the Zenodo sandbox:

- the new-version action only accepts the *latest published version's* id, not the concept id - so the concept is resolved through `/records/<concept>`, which redirects there;
- a draft nobody published yet blocks the new-version action (with a misleading "please remove all files first"). That draft is picked up and reused instead, with a warning in the run, since this release supersedes it anyway. Otherwise a forgotten draft would break the next release.

### Record metadata

Added as `.zenodo.json` (Zenodo's own convention for this), filled from `CITATION.cff` so it stays maintainable next to it rather than inside the workflow: the four authors with affiliations, the abstract, keywords, AGPL-3.0-or-later, the community, and the paper (`10.1016/j.jbef.2024.100891`) as a related identifier. The workflow only adds the version and the release link, so the record points back at both the paper and the exact release it was built from.

### Notes

- Plain `curl` against the deposition API rather than a third-party action, to keep the release pipeline's dependency surface small. Files go through the bucket endpoint (50 GB per file; the legacy files endpoint caps at 100 MB).
- The step is skipped when no `ZENODO_TOKEN` is configured, so forks are unaffected. `vars.ZENODO_BASE` points it at `sandbox.zenodo.org` for rehearsals.
- Job timeout raised 30 -> 60 min: build ~13 min plus ~13 min to upload 2.9 GB left almost no headroom.

### Verified

Rehearsed end-to-end against the Zenodo sandbox from CI, on a real 2.9 GB build: first-record path, new-version path, reuse of an unpublished draft, removal of the files inherited from the previous version, metadata and community assignment, and the draft staying unpublished throughout.

### Open questions

- @JuergenFleiss what is the exact name of the token secret you added? The step expects `ZENODO_TOKEN`.
- The step is the largest one in the workflow. Move it to `.github/scripts/` (shellcheck-able, runnable locally) - now, or once the EXE installer (#221) and Flatpak need the same upload? Happy either way, it just introduces a directory the repo does not have yet.
- Worth seeding the concept with the current release (v1.4.1) manually, so the versioning chain starts at the version people actually run - and that release gets a citable DOI too? Not required technically; the first automated release can start the chain just as well.

cc @gerardo-navarro
