### PR TITLE
build: bump werkzeug 3.0.3 -> 3.1.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "pandas==2.3.3",
   "pyannote.audio==4.0.4",
   "numpy==2.2.2",
-  "werkzeug==3.0.3",
+  "werkzeug==3.1.8",
   "huggingface-hub==0.30.2",
   "torch==2.9.1+cu128; sys_platform == 'win32'",
   "torch==2.9.1; sys_platform != 'win32'",

--- a/uv.lock
+++ b/uv.lock
@@ -281,7 +281,7 @@ requires-dist = [
     { name = "torchaudio", marker = "sys_platform == 'win32'", specifier = "==2.9.1+cu128", index = "https://download.pytorch.org/whl/cu128" },
     { name = "typer", specifier = "==0.16.0" },
     { name = "wakepy", marker = "extra == 'gui'", specifier = "==0.7.2" },
-    { name = "werkzeug", specifier = "==3.0.3" },
+    { name = "werkzeug", specifier = "==3.1.8" },
 ]
 provides-extras = ["gui"]
 
@@ -4582,14 +4582,14 @@ wheels = [
 
 [[package]]
 name = "werkzeug"
-version = "3.0.3"
+version = "3.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/02/51/2e0fc149e7a810d300422ab543f87f2bcf64d985eb6f1228c4efd6e4f8d4/werkzeug-3.0.3.tar.gz", hash = "sha256:097e5bfda9f0aba8da6b8545146def481d06aa7d3266e7448e2cccf67dd8bd18", size = 803342, upload-time = "2024-05-05T23:10:31.999Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/6e/e792999e816d19d7fcbfa94c730936750036d65656a76a5a688b57a656c4/werkzeug-3.0.3-py3-none-any.whl", hash = "sha256:fc9645dc43e03e4d630d23143a04a7f947a9a3b5727cd535fdfe155a17cc48c8", size = 227274, upload-time = "2024-05-05T23:10:29.567Z" },
+    { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459, upload-time = "2026-04-02T18:49:12.72Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Clears the two advisories `pip-audit` reports on every run: PYSEC-2026-2320 (`safe_join` accepts Windows device names, fixed in 3.1.6) and PYSEC-2026-3417 (resource exhaustion parsing form data, fixed in 3.0.6).

Checked before bumping:

- werkzeug is a direct dependency used for one function, `secure_filename` in `aTrain_core/transcribe.py`, and nothing else in the lockfile constrains it.
- `secure_filename` returns identical results on 3.0.3 and 3.1.8 for 17 inputs (path traversal, Windows device names, unicode, null bytes, overlong names).
- Local `tests/unit` + `tests/ui` green.

cc @gerardo-navarro
